### PR TITLE
Sof 415  Fix to only ignore messages once at boot, even if the network delays.  

### DIFF
--- a/common/interfaces/state.go
+++ b/common/interfaces/state.go
@@ -62,10 +62,10 @@ type IState interface {
 	// is a follower's state, but it is also critical to validation; we cannot
 	// validate transactions where the HighestRecordedBlock+1 != block holding said
 	// transaction.
-	GetHighestCompletedBlock() uint32
+	GetHighestSavedBlk() uint32
 	// This is the highest block saved in the Database. A block is completed, then validated
 	// then saved.
-	GetHighestSavedBlock() uint32
+	GetHighestCompletedBlk() uint32
 	// This is the Leader's view of the Height. It must be == HighestRecordedBlock+1.  Since
 	// Recording a block can take time, messages must be queued until the previous block is
 	// recorded (either by processing messages, or timing out and Leaders signing off the block)

--- a/common/messages/dbstate.go
+++ b/common/messages/dbstate.go
@@ -155,12 +155,12 @@ func (m *DBStateMsg) Validate(state interfaces.IState) int {
 		return -1
 	}
 
-	diff := int(dbheight) - (int(state.GetHighestCompletedBlock()) + 1) // Difference from the working height (completed+1)
+	diff := int(dbheight) - (int(state.GetHighestSavedBlk()) + 1) // Difference from the working height (completed+1)
 
 	if (diff < -2 || diff > 2) && dbheight > 1 {
 		if diff > -3 && diff < 3 {
 			state.AddStatus(fmt.Sprintf("DBStateMsg.Validate() Fail dbht: %d Highest Completed %d diff %d",
-				dbheight, state.GetHighestCompletedBlock(), diff))
+				dbheight, state.GetHighestSavedBlk(), diff))
 		}
 		if diff > 0 {
 			return 0

--- a/common/messages/dbstate_test.go
+++ b/common/messages/dbstate_test.go
@@ -69,16 +69,16 @@ func TestDBStateMsgValidate(t *testing.T) {
 	}
 
 	msg = newDBStateMsg()
-	msg.DirectoryBlock.GetHeader().SetDBHeight(state.GetHighestCompletedBlock() + 1)
-	constants.CheckPoints[state.GetHighestCompletedBlock()+1] = "123"
+	msg.DirectoryBlock.GetHeader().SetDBHeight(state.GetHighestSavedBlk() + 1)
+	constants.CheckPoints[state.GetHighestSavedBlk()+1] = "123"
 	if msg.Validate(state) >= 0 {
 		t.Errorf("Wrong checkpoint validated")
 	}
 
-	delete(constants.CheckPoints, state.GetHighestCompletedBlock()+1)
+	delete(constants.CheckPoints, state.GetHighestSavedBlk()+1)
 
 	msg = newDBStateMsg()
-	msg.DirectoryBlock.GetHeader().SetDBHeight(state.GetHighestCompletedBlock() + 1)
+	msg.DirectoryBlock.GetHeader().SetDBHeight(state.GetHighestSavedBlk() + 1)
 	if msg.Validate(state) <= 0 {
 		t.Errorf("Proper block not validated!")
 	}

--- a/engine/printSummary.go
+++ b/engine/printSummary.go
@@ -290,7 +290,7 @@ func faultSummary() string {
 
 	for i, fnode := range fnodes {
 		if verboseFaultOutput || !fnode.State.GetNetStateOff() {
-			b := fnode.State.GetHighestCompletedBlock()
+			b := fnode.State.GetHighestSavedBlk()
 			pl := fnode.State.ProcessLists.Get(b + 1)
 			if pl == nil {
 				pl = fnode.State.ProcessLists.Get(b)

--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -1038,7 +1038,7 @@ func printProcessList(watchPL *int, value int, listenTo *int) {
 	for *watchPL == value {
 		fnode := fnodes[*listenTo]
 		nprt := fnode.State.DBStates.String()
-		b := fnode.State.GetHighestCompletedBlock()
+		b := fnode.State.GetHighestSavedBlk()
 		fnode.State.ProcessLists.SetString = true
 		nprt = nprt + fnode.State.ProcessLists.Str
 		pl := fnode.State.ProcessLists.Get(b)

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -185,7 +185,7 @@ func (ds *DBState) String() string {
 	return str
 }
 
-func (list *DBStateList) GetHighestSavedBlock() uint32 {
+func (list *DBStateList) GetHighestCompletedBlk() uint32 {
 	ht := list.Base
 	for i, dbstate := range list.DBStates {
 		if dbstate != nil && dbstate.Locked {
@@ -199,7 +199,7 @@ func (list *DBStateList) GetHighestSavedBlock() uint32 {
 	return ht
 }
 
-func (list *DBStateList) GetHighestCompletedBlock() uint32 {
+func (list *DBStateList) GetHighestSavedBlk() uint32 {
 	ht := list.Base
 	for i, dbstate := range list.DBStates {
 		if dbstate != nil && dbstate.Saved {
@@ -218,7 +218,7 @@ func (list *DBStateList) Catchup() {
 
 	now := list.State.GetTimestamp()
 
-	dbsHeight := list.GetHighestCompletedBlock()
+	dbsHeight := list.GetHighestSavedBlk()
 
 	// We only check if we need updates once every so often.
 
@@ -841,7 +841,7 @@ func (list *DBStateList) NewDBState(isNew bool,
 		return dbState
 	} else {
 		ht := dbState.DirectoryBlock.GetHeader().GetDBHeight()
-		if ht == list.State.GetHighestSavedBlock() {
+		if ht == list.State.GetHighestCompletedBlk() {
 			index := int(ht) - int(list.State.DBStates.Base)
 			if index > 0 {
 				list.State.DBStates.DBStates[index] = dbState

--- a/state/processList.go
+++ b/state/processList.go
@@ -207,7 +207,7 @@ func (p *ProcessList) LenNewEntries() int {
 }
 
 func (p *ProcessList) Complete() bool {
-	if p.DBHeight <= p.State.GetHighestCompletedBlock() {
+	if p.DBHeight <= p.State.GetHighestSavedBlk() {
 		return true
 	}
 	for i := 0; i < len(p.FedServers); i++ {
@@ -699,7 +699,7 @@ func (p *ProcessList) TrimVMList(height uint32, vmIndex int) {
 // Process messages and update our state.
 func (p *ProcessList) Process(state *State) (progress bool) {
 
-	dbht := state.GetHighestCompletedBlock()
+	dbht := state.GetHighestSavedBlk()
 	if dbht >= p.DBHeight {
 		return true
 	}
@@ -1215,7 +1215,7 @@ func (p *ProcessList) Reset() bool {
 	s.StartDelay = s.GetTimestamp().GetTimeMilli()
 	s.RunLeader = false
 
-	s.LLeaderHeight = s.GetHighestCompletedBlock() + 1
+	s.LLeaderHeight = s.GetHighestSavedBlk() + 1
 	s.LeaderPL = s.ProcessLists.Get(s.LLeaderHeight)
 
 	s.Leader, s.LeaderVMIndex = s.LeaderPL.GetVirtualServers(s.CurrentMinute, s.IdentityChainID)

--- a/state/state.go
+++ b/state/state.go
@@ -158,6 +158,7 @@ type State struct {
 
 	// Ignore missing messages for a period to allow rebooting a network where your
 	// own messages from the previously executing network can confuse you.
+	IgnoreDone    bool
 	IgnoreMissing bool
 
 	LLeaderHeight   uint32
@@ -1365,7 +1366,7 @@ func (s *State) GetDirectoryBlockByHeight(height uint32) interfaces.IDirectoryBl
 }
 
 func (s *State) UpdateState() (progress bool) {
-	dbheight := s.GetHighestCompletedBlock()
+	dbheight := s.GetHighestSavedBlk()
 	plbase := s.ProcessLists.DBHeightBase
 	if dbheight == 0 {
 		dbheight++
@@ -1465,7 +1466,7 @@ func (s *State) catchupEBlocks() {
 		// missing, we stop moving the bookmark, and rely on caching to keep us from thrashing the disk as we
 		// review the directory block over again the next time.
 		alldone := true
-		for s.EntryBlockDBHeightProcessing < s.GetHighestCompletedBlock() && len(s.MissingEntryBlocks) < 20 {
+		for s.EntryBlockDBHeightProcessing < s.GetHighestSavedBlk() && len(s.MissingEntryBlocks) < 20 {
 			dbstate := s.DBStates.Get(int(s.EntryBlockDBHeightProcessing))
 
 			if dbstate != nil {
@@ -2012,7 +2013,7 @@ func (s *State) SetStringQueues() {
 	case s.DBStates.Last().DirectoryBlock == nil:
 
 	default:
-		d = s.DBStates.Get(int(s.GetHighestSavedBlock())).DirectoryBlock
+		d = s.DBStates.Get(int(s.GetHighestCompletedBlk())).DirectoryBlock
 		keyMR = d.GetKeyMR().Bytes()
 		dHeight = d.GetHeader().GetDBHeight()
 	}

--- a/state/stateDisplay.go
+++ b/state/stateDisplay.go
@@ -103,7 +103,7 @@ func DeepStateDisplayCopy(s *State) (*DisplayState, error) {
 	ds.ControlPanelSetting = s.ControlPanelSetting
 
 	// DB Info
-	ds.CurrentNodeHeight = s.GetHighestCompletedBlock()
+	ds.CurrentNodeHeight = s.GetHighestSavedBlk()
 	ds.CurrentLeaderHeight = s.GetLeaderHeight()
 	ds.CurrentEBDBHeight = s.EntryBlockDBHeightProcessing
 	ds.LeaderHeight = s.GetTrueLeaderHeight()
@@ -204,7 +204,7 @@ func DeepStateDisplayCopy(s *State) (*DisplayState, error) {
 
 	ds.RawSummary = prt
 
-	b := s.GetHighestCompletedBlock()
+	b := s.GetHighestSavedBlk()
 	pl := s.ProcessLists.Get(b + 1)
 	if pl == nil {
 		pl = s.ProcessLists.Get(b)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -41,7 +41,7 @@ func TestSecretCode(t *testing.T) {
 
 func TestDirBlockHead(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	height := state.GetHighestCompletedBlock()
+	height := state.GetHighestSavedBlk()
 	if height != 9 {
 		t.Errorf("Invalid DBLock Height - got %v, expected 10", height+1)
 	}

--- a/testHelper/testHelper_test.go
+++ b/testHelper/testHelper_test.go
@@ -57,7 +57,7 @@ func Test(t *testing.T) {
 
 func Test_DB_With_Ten_Blks(t *testing.T) {
 	state := CreateAndPopulateTestState()
-	t.Log("Highest Recorded Block: ", state.GetHighestCompletedBlock())
+	t.Log("Highest Recorded Block: ", state.GetHighestSavedBlk())
 }
 
 /*

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -438,7 +438,7 @@ func HandleV2RevealEntry(state interfaces.IState, params interface{}) (interface
 
 func HandleV2DirectoryBlockHead(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
 	h := new(DirectoryBlockHeadResponse)
-	d := state.GetDirectoryBlockByHeight(state.GetHighestCompletedBlock())
+	d := state.GetDirectoryBlockByHeight(state.GetHighestSavedBlk())
 	h.KeyMR = d.GetKeyMR().String()
 	return h, nil
 }
@@ -811,9 +811,9 @@ func HandleV2FactoidBalance(state interfaces.IState, params interface{}) (interf
 func HandleV2Heights(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
 	h := new(HeightsResponse)
 
-	h.DirectoryBlockHeight = int64(state.GetHighestCompletedBlock())
+	h.DirectoryBlockHeight = int64(state.GetHighestSavedBlk())
 	h.LeaderHeight = int64(state.GetTrueLeaderHeight())
-	h.EntryBlockHeight = int64(state.GetHighestCompletedBlock())
+	h.EntryBlockHeight = int64(state.GetHighestSavedBlk())
 	h.EntryHeight = int64(state.GetEntryDBHeightComplete())
 	h.MissingEntryCount = int64(state.GetMissingEntryCount())
 	h.EntryBlockDBHeightProcessing = int64(state.GetEntryBlockDBHeightProcessing())


### PR DESCRIPTION
This is actually just a small update.  Rolled into this is also a fix to GetHighestSavedBlk() and GetHighestCompletedBlk() which were reversed in actual function.  This change is just a rename of one for the other in the code.