### PR TITLE
Sof 399:  Wait to the EOM before we save to disk

### DIFF
--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -931,10 +931,11 @@ func SimControl(listenTo int) {
 					if dbs == nil {
 						os.Stderr.WriteString(fmt.Sprintf("%2d DBState            nil\n", i))
 					} else {
-						os.Stderr.WriteString(fmt.Sprintf("%2d DBState                          IsNew[%5v] Locked [%5v] ReadyToSave [%5v] Saved [%5v]\n%v", i,
+						os.Stderr.WriteString(fmt.Sprintf("%2d DBState                          IsNew[%5v]  ReadyToSave [%5v] Locked [%5v] Signed [%5v] Saved [%5v]\n%v", i,
 							dbs.IsNew,
-							dbs.Locked,
 							dbs.ReadyToSave,
+							dbs.Locked,
+							dbs.Signed,
 							dbs.Saved,
 							dbs.String()))
 					}

--- a/state/processList.go
+++ b/state/processList.go
@@ -812,11 +812,10 @@ func (p *ProcessList) Process(state *State) (progress bool) {
 			// So here is the deal.  After we have processed a block, we have to allow the DirectoryBlockSignatures a chance to save
 			// to disk.  Then we can insist on having the entry blocks.
 			diff := p.DBHeight - state.EntryBlockDBHeightComplete
-			_, dbsig := vm.List[j].(*messages.DirectoryBlockSignature)
 
 			// Keep in mind, the process list is processing at a height one greater than the database. 1 is caught up.  2 is one behind.
 			// Until the signatures are processed, we will be 2 behind.
-			if (dbsig && diff <= 2) || diff <= 1 {
+			if diff <= 2 {
 				// If we can't process this entry (i.e. returns false) then we can't process any more.
 				p.NextHeightToProcess[i] = j + 1
 				if vm.List[j].Process(p.DBHeight, state) { // Try and Process this entry
@@ -1062,11 +1061,17 @@ func (p *ProcessList) String() string {
 		buf.WriteString("===ProcessListStart===\n")
 
 		pdbs := p.State.DBStates.Get(int(p.DBHeight - 1))
-		saved := "n"
-		if pdbs != nil && pdbs.Saved {
-			saved = "y"
+		saved := ""
+		if pdbs == nil {
+			saved = "nil"
+		} else if pdbs.Signed {
+			saved = "signed"
+		} else if pdbs.Saved {
+			saved = "saved"
+		} else {
+			saved = "constructing"
 		}
-		buf.WriteString(fmt.Sprintf("%s #VMs %d Complete %v DBHeight %d DBSig %v EOM %v p-dbstate.Saved = %s\n",
+		buf.WriteString(fmt.Sprintf("%s #VMs %d Complete %v DBHeight %d DBSig %v EOM %v p-dbstate = %s\n",
 			p.State.GetFactomNodeName(),
 			len(p.FedServers),
 			p.Complete(),

--- a/state/processListManager.go
+++ b/state/processListManager.go
@@ -46,7 +46,7 @@ func (lists *ProcessLists) UpdateState(dbheight uint32) (progress bool) {
 	}
 	dbstate := lists.State.DBStates.Get(int(dbheight))
 	pl := lists.Get(dbheight)
-	for pl.Complete() || (dbstate != nil && dbstate.Saved) {
+	for pl.Complete() || (dbstate != nil && dbstate.Signed) {
 		dbheight++
 		pl = lists.Get(dbheight)
 		dbstate = lists.State.DBStates.Get(int(dbheight))

--- a/state/state.go
+++ b/state/state.go
@@ -1466,7 +1466,7 @@ func (s *State) catchupEBlocks() {
 		// missing, we stop moving the bookmark, and rely on caching to keep us from thrashing the disk as we
 		// review the directory block over again the next time.
 		alldone := true
-		for s.EntryBlockDBHeightProcessing < s.GetHighestSavedBlk() && len(s.MissingEntryBlocks) < 20 {
+		for s.EntryBlockDBHeightProcessing < s.GetHighestCompletedBlk() && len(s.MissingEntryBlocks) < 20 {
 			dbstate := s.DBStates.Get(int(s.EntryBlockDBHeightProcessing))
 
 			if dbstate != nil {

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -1372,7 +1372,7 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 		// disagree with us, null our entry out.  Otherwise toss our DBState and ask for one from
 		// our neighbors.
 		if s.KeepMismatch || pl.CheckDiffSigTally() {
-			if !dbstate.Signed {
+			if !dbstate.Saved {
 				dbstate.ReadyToSave = true
 				s.DBStates.SaveDBStateToDB(dbstate)
 				//s.LeaderPL.AddDBSig(dbs.ServerIdentityChainID, dbs.DBSignature)

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -1372,7 +1372,7 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 		// disagree with us, null our entry out.  Otherwise toss our DBState and ask for one from
 		// our neighbors.
 		if s.KeepMismatch || pl.CheckDiffSigTally() {
-			if !dbstate.Saved {
+			if !dbstate.Signed {
 				dbstate.ReadyToSave = true
 				s.DBStates.SaveDBStateToDB(dbstate)
 				//s.LeaderPL.AddDBSig(dbs.ServerIdentityChainID, dbs.DBSignature)


### PR DESCRIPTION
Avoids issues with backing out the database when blocks are not shared among the leaders.