### PR TITLE
Sof 439

### DIFF
--- a/state/ack.go
+++ b/state/ack.go
@@ -193,11 +193,19 @@ func (s *State) FetchECTransactionByHash(hash interfaces.IHash) (interfaces.IECB
 		return nil, nil
 	}
 
-	ecBlock := s.ProcessLists.LastList().EntryCreditBlock
-	if ecBlock != nil {
-		tx := ecBlock.GetEntryByHash(hash)
-		if tx != nil {
-			return tx, nil
+	var currentHeightComplete = s.GetDBHeightComplete()
+	pls := s.ProcessLists.Lists
+	for _, pl := range pls {
+		if pl != nil {
+			if pl.DBHeight > currentHeightComplete {
+				ecBlock := pl.EntryCreditBlock
+				if ecBlock != nil {
+					tx := ecBlock.GetEntryByHash(hash)
+					if tx != nil {
+						return tx, nil
+					}
+				}
+			}
 		}
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -1064,6 +1064,7 @@ func (s *State) fillAcksMap() {
 }
 
 func (s *State) GetPendingEntries(params interface{}) []interfaces.IPendingEntry {
+	fmt.Println("GetPendingEntries")
 	resp := make([]interfaces.IPendingEntry, 0)
 	pls := s.ProcessLists.Lists
 	var cc messages.CommitChainMsg
@@ -1073,65 +1074,73 @@ func (s *State) GetPendingEntries(params interface{}) []interfaces.IPendingEntry
 	LastComplete := s.GetDBHeightComplete()
 	// check all existing processlists/VMs
 	for _, pl := range pls {
-		if pl.DBHeight > LastComplete {
-			for _, v := range pl.VMs {
-				for _, plmsg := range v.List {
-					if plmsg.Type() == constants.COMMIT_CHAIN_MSG { //5
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil
-						}
-						err = cc.UnmarshalBinary(enb)
-						if err != nil {
-							return nil
-						}
-						tmp.EntryHash = cc.CommitChain.EntryHash
+		if pls != nil {
+			if pl.DBHeight > LastComplete {
+				for _, v := range pl.VMs {
+					for _, plmsg := range v.List {
+						if plmsg.Type() == constants.COMMIT_CHAIN_MSG { //5
+							enb, err := plmsg.MarshalBinary()
+							if err != nil {
+								return nil
+							}
+							err = cc.UnmarshalBinary(enb)
+							if err != nil {
+								return nil
+							}
+							tmp.EntryHash = cc.CommitChain.EntryHash
 
-						tmp.ChainID = cc.CommitChain.ChainIDHash
-						if pl.DBHeight > s.GetDBHeightComplete() {
-							tmp.Status = "AckStatusACK"
-						} else {
-							tmp.Status = "AckStatusDBlockConfirmed"
-						}
+							tmp.ChainID = cc.CommitChain.ChainIDHash
+							if pl.DBHeight > s.GetDBHeightComplete() {
+								tmp.Status = "AckStatusACK"
+							} else {
+								tmp.Status = "AckStatusDBlockConfirmed"
+							}
 
-						resp = append(resp, tmp)
-					} else if plmsg.Type() == constants.COMMIT_ENTRY_MSG { //6
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil
-						}
-						err = ce.UnmarshalBinary(enb)
-						if err != nil {
-							return nil
-						}
-						tmp.EntryHash = ce.CommitEntry.EntryHash
+							if util.IsInPendingEntryList(resp, tmp) {
+								resp = append(resp, tmp)
+							}
+						} else if plmsg.Type() == constants.COMMIT_ENTRY_MSG { //6
+							enb, err := plmsg.MarshalBinary()
+							if err != nil {
+								return nil
+							}
+							err = ce.UnmarshalBinary(enb)
+							if err != nil {
+								return nil
+							}
+							tmp.EntryHash = ce.CommitEntry.EntryHash
 
-						tmp.ChainID = ce.CommitEntry.Hash()
-						if pl.DBHeight > s.GetDBHeightComplete() {
-							tmp.Status = "AckStatusACK"
-						} else {
-							tmp.Status = "AckStatusDBlockConfirmed"
-						}
+							tmp.ChainID = nil
+							if pl.DBHeight > s.GetDBHeightComplete() {
+								tmp.Status = "AckStatusACK"
+							} else {
+								tmp.Status = "AckStatusDBlockConfirmed"
+							}
 
-						resp = append(resp, tmp)
-					} else if plmsg.Type() == constants.REVEAL_ENTRY_MSG { //13
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil
-						}
-						err = re.UnmarshalBinary(enb)
-						if err != nil {
-							return nil
-						}
-						tmp.EntryHash = re.Entry.GetHash()
-						tmp.ChainID = re.Entry.GetChainID()
-						if pl.DBHeight > s.GetDBHeightComplete() {
-							tmp.Status = "AckStatusACK"
-						} else {
-							tmp.Status = "AckStatusDBlockConfirmed"
-						}
+							if !util.IsInPendingEntryList(resp, tmp) {
+								resp = append(resp, tmp)
+							}
+						} else if plmsg.Type() == constants.REVEAL_ENTRY_MSG { //13
+							enb, err := plmsg.MarshalBinary()
+							if err != nil {
+								return nil
+							}
+							err = re.UnmarshalBinary(enb)
+							if err != nil {
+								return nil
+							}
+							tmp.EntryHash = re.Entry.GetHash()
+							tmp.ChainID = re.Entry.GetChainID()
+							if pl.DBHeight > s.GetDBHeightComplete() {
+								tmp.Status = "AckStatusACK"
+							} else {
+								tmp.Status = "AckStatusDBlockConfirmed"
+							}
 
-						resp = append(resp, tmp)
+							if !util.IsInPendingEntryList(resp, tmp) {
+								resp = append(resp, tmp)
+							}
+						}
 					}
 				}
 			}
@@ -1155,8 +1164,9 @@ func (s *State) GetPendingEntries(params interface{}) []interfaces.IPendingEntry
 
 			tmp.ChainID = re.Entry.GetChainID()
 			tmp.Status = "AckStatusNotConfirmed"
-
-			resp = append(resp, tmp)
+			if !util.IsInPendingEntryList(resp, tmp) {
+				resp = append(resp, tmp)
+			}
 		}
 	}
 
@@ -1171,33 +1181,35 @@ func (s *State) GetPendingTransactions(params interface{}) []interfaces.IPending
 	resp := make([]interfaces.IPendingTransaction, 0)
 	pls := s.ProcessLists.Lists
 	for _, pl := range pls {
-		// ignore old process lists
-		if pl.DBHeight > currentHeightComplete {
-			cb := pl.State.FactoidState.GetCurrentBlock()
-			ct := cb.GetTransactions()
-			for _, tran := range ct {
-				var tmp interfaces.IPendingTransaction
-				tmp.TransactionID = tran.GetSigHash()
-				if tran.GetBlockHeight() > 0 {
-					tmp.Status = "AckStatusDBlockConfirmed"
-				} else {
-					tmp.Status = "AckStatusACK"
-				}
-				if params.(string) == "" {
-					flgFound = true
-				} else {
-					flgFound = tran.HasUserAddress(params.(string))
-				}
-				if flgFound == true {
-					//working through multiple process lists.  Is this transaction already in the list?
-					for _, pt := range resp {
-						if pt.TransactionID.String() == tmp.TransactionID.String() {
-							flgFound = false
-						}
+		if pl != nil {
+			// ignore old process lists
+			if pl.DBHeight > currentHeightComplete {
+				cb := pl.State.FactoidState.GetCurrentBlock()
+				ct := cb.GetTransactions()
+				for _, tran := range ct {
+					var tmp interfaces.IPendingTransaction
+					tmp.TransactionID = tran.GetSigHash()
+					if tran.GetBlockHeight() > 0 {
+						tmp.Status = "AckStatusDBlockConfirmed"
+					} else {
+						tmp.Status = "AckStatusACK"
 					}
-					//  flag was true to be added to the list and not already in the list
+					if params.(string) == "" {
+						flgFound = true
+					} else {
+						flgFound = tran.HasUserAddress(params.(string))
+					}
 					if flgFound == true {
-						resp = append(resp, tmp)
+						//working through multiple process lists.  Is this transaction already in the list?
+						for _, pt := range resp {
+							if pt.TransactionID.String() == tmp.TransactionID.String() {
+								flgFound = false
+							}
+						}
+						//  flag was true to be added to the list and not already in the list
+						if flgFound == true {
+							resp = append(resp, tmp)
+						}
 					}
 				}
 			}
@@ -1250,58 +1262,60 @@ func (s *State) FetchEntryHashFromProcessListsByTxID(txID string) (interfaces.IH
 
 	// check all existing processlists (last complete block +1 and greater)
 	for _, pl := range pls {
+		if pl != nil {
+			for _, v := range pl.VMs {
+				if v != nil {
+					// check chain commits
+					for _, plmsg := range v.List {
+						if plmsg != nil {
 
-		for _, v := range pl.VMs {
+							//	if plmsg.Type() != nil {
+							if plmsg.Type() == constants.COMMIT_CHAIN_MSG { //5 other types could be in this VM
+								enb, err := plmsg.MarshalBinary()
+								if err != nil {
+									return nil, err
+								}
+								err = cc.UnmarshalBinary(enb)
+								if err != nil {
+									return nil, err
+								}
+								if cc.CommitChain.GetSigHash().String() == txID {
+									return cc.CommitChain.EntryHash, nil
+								}
+							} else if plmsg.Type() == constants.COMMIT_ENTRY_MSG { //6
 
-			// check chain commits
-			for _, plmsg := range v.List {
-				if plmsg != nil {
+								enb, err := plmsg.MarshalBinary()
+								if err != nil {
+									return nil, err
+								}
+								err = ce.UnmarshalBinary(enb)
+								if err != nil {
+									return nil, err
+								}
 
-					//	if plmsg.Type() != nil {
-					if plmsg.Type() == constants.COMMIT_CHAIN_MSG { //5 other types could be in this VM
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil, err
-						}
-						err = cc.UnmarshalBinary(enb)
-						if err != nil {
-							return nil, err
-						}
-						if cc.CommitChain.GetSigHash().String() == txID {
-							return cc.CommitChain.EntryHash, nil
-						}
-					} else if plmsg.Type() == constants.COMMIT_ENTRY_MSG { //6
+								if ce.CommitEntry.GetSigHash().String() == txID {
+									return ce.CommitEntry.EntryHash, nil
+								}
 
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil, err
+							} else if plmsg.Type() == constants.REVEAL_ENTRY_MSG { //13
+								enb, err := plmsg.MarshalBinary()
+								if err != nil {
+									return nil, err
+								}
+								err = re.UnmarshalBinary(enb)
+								if err != nil {
+									return nil, err
+								}
+								if re.Entry.GetHash().String() == txID {
+									return re.Entry.GetHash(), nil
+								}
+							}
 						}
-						err = ce.UnmarshalBinary(enb)
-						if err != nil {
-							return nil, err
-						}
-
-						if ce.CommitEntry.GetSigHash().String() == txID {
-							return ce.CommitEntry.EntryHash, nil
-						}
-
-					} else if plmsg.Type() == constants.REVEAL_ENTRY_MSG { //13
-						enb, err := plmsg.MarshalBinary()
-						if err != nil {
-							return nil, err
-						}
-						err = re.UnmarshalBinary(enb)
-						if err != nil {
-							return nil, err
-						}
-						if re.Entry.GetHash().String() == txID {
-							return re.Entry.GetHash(), nil
-						}
+						//	} else {
+						//		return nil, fmt.Errorf("%s", "Invalid Message in Holding Queue")
+						//	}
 					}
 				}
-				//	} else {
-				//		return nil, fmt.Errorf("%s", "Invalid Message in Holding Queue")
-				//	}
 			}
 		}
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -1107,7 +1107,7 @@ func (s *State) GetPendingEntries(params interface{}) []interfaces.IPendingEntry
 	LastComplete := s.GetDBHeightComplete()
 	// check all existing processlists/VMs
 	for _, pl := range pls {
-		if pls != nil {
+		if pl != nil {
 			if pl.DBHeight > LastComplete {
 				for _, v := range pl.VMs {
 					for _, plmsg := range v.List {

--- a/util/misc.go
+++ b/util/misc.go
@@ -2,9 +2,11 @@ package util
 
 import (
 	"fmt"
-	"github.com/FactomProject/factomd/log"
 	"runtime"
 	"time"
+
+	"github.com/FactomProject/factomd/common/interfaces"
+	"github.com/FactomProject/factomd/log"
 )
 
 // a simple file/line trace function, with optional comment(s)
@@ -54,4 +56,20 @@ func EntryCost(b []byte) (uint8, error) {
 	}
 
 	return n, nil
+}
+
+func IsInPendingEntryList(list []interfaces.IPendingEntry, entry interfaces.IPendingEntry) bool {
+	if len(list) == 0 {
+		return false
+	}
+	for _, ent := range list {
+		if ent.EntryHash != nil {
+			if entry.EntryHash.IsSameAs(ent.EntryHash) {
+				if entry.ChainID.IsSameAs(ent.ChainID) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
avoided re-adding pending entries when already in response

added IsInPendingEntryList to factomd/util/misc.go 

added a couple nil checks the are part of other SOF tasks, but arent in yet.

got rid of s.ProcessLists.LastList() in favor of iterating through last 2 which works better