### PR TITLE
updated v1 commit entry api

### DIFF
--- a/wsapi/wsapi.go
+++ b/wsapi/wsapi.go
@@ -311,7 +311,9 @@ func HandleCommitEntry(ctx *web.Context) {
 		}
 	}
 
-	param := EntryRequest{Entry: c.CommitEntryMsg}
+	//  v2 wants a MessageRequest instead of an EntryRequest
+	//	param := EntryRequest{Entry: c.CommitEntryMsg}
+	param := MessageRequest{Message: c.CommitEntryMsg}
 	req := primitives.NewJSON2Request("commit-entry", 1, param)
 
 	_, jsonError := HandleV2Request(state, req)


### PR DESCRIPTION
a change to the v2 api call that enabled corrected identity utilization
changes an entry request to a message request.  updated api v1 skin to
messageRequest