### PR TITLE
Panic on errors in config file (Rather than silently load defaults)

### DIFF
--- a/util/config.go
+++ b/util/config.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/FactomProject/factomd/common/primitives"
-	"github.com/FactomProject/factomd/log"
 
 	"gopkg.in/gcfg.v1"
 )
@@ -279,14 +278,9 @@ func ReadConfig(filename string) *FactomdConfig {
 		panic(err)
 	}
 
-	err = gcfg.FatalOnly(gcfg.ReadFileInto(cfg, filename))
+	err = gcfg.ReadFileInto(cfg, filename)
 	if err != nil {
-		log.Printfln("Reading from '%s'", filename)
-		log.Printfln("Cannot open custom config file,\nStarting with default settings.\n%v\n", err)
-		err = gcfg.ReadStringInto(cfg, defaultConfig)
-		if err != nil {
-			panic(err)
-		}
+		panic(err)
 	}
 
 	// Default to home directory if not set

--- a/util/config.go
+++ b/util/config.go
@@ -279,7 +279,7 @@ func ReadConfig(filename string) *FactomdConfig {
 		panic(err)
 	}
 
-	err = gcfg.ReadFileInto(cfg, filename)
+	err = gcfg.FatalOnly(gcfg.ReadFileInto(cfg, filename))
 	if err != nil {
 		log.Printfln("Reading from '%s'", filename)
 		log.Printfln("Cannot open custom config file,\nStarting with default settings.\n%v\n", err)


### PR DESCRIPTION
Setting parameters that don't map to real values in our struct will no longer cause factomd to completely ignore the config file and revert to the defaults. 