### PR TITLE
check for nil

### DIFF
--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -465,6 +465,10 @@ func (list *DBStateList) ProcessBlocks(d *DBState) (progress bool) {
 	pl := list.State.ProcessLists.Get(ht)
 	pln := list.State.ProcessLists.Get(ht + 1)
 
+	if pl == nil {
+		return
+	}
+
 	var out bytes.Buffer
 	out.WriteString("=== AdminBlock.UpdateState() Start ===\n")
 	prt := func(lable string, pl *ProcessList) {


### PR DESCRIPTION
I keep putting this in, and it keeps getting lost in the shuffle. 

Ignore the nil process list, return, and process later when the ducks are actually in order.