### PR TITLE
SOF-514: network buffering

### DIFF
--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -5,6 +5,7 @@
 package p2p
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/gob"
 	"fmt"
@@ -27,6 +28,8 @@ type Connection struct {
 	// and as "address" for sending messages to specific nodes.
 	encoder         *gob.Encoder      // Wire format is gobs in this version, may switch to binary
 	decoder         *gob.Decoder      // Wire format is gobs in this version, may switch to binary
+	reader          *bufio.Reader     // A reader for buffering data read from the connection
+	writer          *bufio.Writer     // A writer for buffering data written to the connection
 	peer            Peer              // the datastructure representing the peer we are talking to. defined in peer.go
 	attempts        int               // reconnection attempts
 	timeLastAttempt time.Time         // time of last attempt to connect via dial
@@ -344,8 +347,10 @@ func (c *Connection) goOnline() {
 	debug(c.peer.PeerIdent(), "Connection.goOnline() called.")
 	c.state = ConnectionOnline
 	now := time.Now()
-	c.encoder = gob.NewEncoder(c.conn)
-	c.decoder = gob.NewDecoder(c.conn)
+	c.reader = bufio.NewReaderSize(c.conn, NetworkReadBufferSize)
+	c.writer = bufio.NewWriterSize(c.conn, NetworkWriteBufferSize)
+	c.encoder = gob.NewEncoder(c.writer)
+	c.decoder = gob.NewDecoder(c.reader)
 	c.attempts = 0
 	c.timeLastPing = now
 	c.timeLastAttempt = now
@@ -372,6 +377,8 @@ func (c *Connection) goShutdown() {
 	if nil != c.conn {
 		defer c.conn.Close()
 	}
+	c.writer = nil
+	c.reader = nil
 	c.decoder = nil
 	c.encoder = nil
 	c.state = ConnectionShuttingDown
@@ -441,14 +448,19 @@ func (c *Connection) sendParcel(parcel Parcel) {
 	//c.conn.SetWriteDeadline(deadline)
 
 	parcel.Trace("Connection.sendParcel().encoder.Encode(parcel)", "f")
+	c.writer.Reset(c.conn) // make sure the write buffer is cleaned up after previous errors
 	err := c.encoder.Encode(parcel)
-	switch {
-	case nil == err:
-		c.metrics.BytesSent += parcel.Header.Length
-		c.metrics.MessagesSent += 1
-	default:
+	if nil != err {
 		c.handleNetErrors(err)
+		return
 	}
+	err = c.writer.Flush()
+	if nil != err {
+		c.handleNetErrors(err)
+		return
+	}
+	c.metrics.BytesSent += parcel.Header.Length
+	c.metrics.MessagesSent += 1
 }
 
 // processReceives is called as part of runloop. This is essentially an infinite loop that exits

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -574,7 +574,6 @@ func (c *Connection) parcelValidity(parcel Parcel) uint8 {
 		parcel.Trace("Connection.isValidParcel()-ParcelValid", "H")
 		return ParcelValid
 	}
-	return ParcelValid
 }
 func (c *Connection) handleParcelTypes(parcel Parcel) {
 	switch parcel.Header.Type {

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -49,6 +49,8 @@ var (
 	MinumumSharingQualityScore    int32  = 20          // if a peer's score is less than this we don't share them.
 	OnlySpecialPeers                     = false
 	NetworkDeadline                      = time.Duration(25000) * time.Millisecond
+	NetworkReadBufferSize                = (1024 * 10) // 10kB, size of the read buffer for data sent over the network
+	NetworkWriteBufferSize               = (1024 * 10) // 10kB, size of the write buffer for data sent over the network
 	NumberPeersToConnect                 = 8
 	MaxNumberIncommingConnections        = 150
 	MaxNumberOfRedialAttempts            = 15


### PR DESCRIPTION
After some investigation it looks like gob has a bit of a inconsistent behavior when sending/receiving data:

* in the decoder, the reader is wrapped in a bufio.Reader instance:
  https://github.com/golang/go/blob/master/src/encoding/gob/decoder.go#L39-L42
* the encoder writes everything to the writer in one shot:
  https://github.com/golang/go/blob/master/src/encoding/gob/encoder.go#L81

This means that if when we call `SetReadDeadline` on `c.conn`, the timeout applies to reading a single buffer from the connection (4kB by default), while when we call `SetWriteDeadline` on `c.conn`, the timeout applies to the entire message.

This PR wraps the `c.conn` in the `bufio.Reader` and `bufio.Writer` instances, so that both reads and writes are buffered before sending and the timeouts apply only to a single buffer. The size of the buffer is set in `NetworkReadBufferSize` and `NetworkWriteBufferSize` (10kB right now).

Buffering on the read size should not be necessary (`gob.Decoder` already does that), but I've added it so we have the control over the size of the read buffer.