### PR TITLE
switched getHash call in messages to call messagehash

### DIFF
--- a/common/messages/dbstate.go
+++ b/common/messages/dbstate.go
@@ -105,8 +105,12 @@ func (m *DBStateMsg) GetRepeatHash() interfaces.IHash {
 }
 
 func (m *DBStateMsg) GetHash() interfaces.IHash {
-	data, _ := m.MarshalBinary()
-	return primitives.Sha(data)
+
+	//	data, _ := m.MarshalBinary()
+	//	return primitives.Sha(data)
+
+	// These two calls do the same thing.  It should be standardized.
+	return m.GetMsgHash()
 }
 
 func (m *DBStateMsg) GetMsgHash() interfaces.IHash {


### PR DESCRIPTION
calls the value already helded instead of recomputing it every time.