### PR TITLE
SOF-514: Recreate encoder/decoder when sending data

### DIFF
--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -443,8 +443,12 @@ func (c *Connection) sendParcel(parcel Parcel) {
 	// sent the buffer contents to the socket in chunks, setting the
 	// write deadline on each chunk
 	bytesToSend := encoded.Bytes()
+
+	significant(c.peer.PeerIdent(), "bytesToSend %x", bytesToSend)
+
 	for start := 0; start < len(bytesToSend); start += NetworkWriteBufferSize {
 		end := min(start+NetworkWriteBufferSize, len(bytesToSend))
+		significant(c.peer.PeerIdent(), "sending bytes from %d to %d %x", start, end, bytesToSend[start:end])
 
 		c.conn.SetWriteDeadline(time.Now().Add(NetworkDeadline))
 		_, err = c.conn.Write(bytesToSend[start:end])
@@ -477,6 +481,10 @@ func (c *Connection) processReceives() {
 		verbose(c.peer.PeerIdent(), "Connection.processReceives() called. State: %s", c.ConnectionState())
 
 		var bufReader = bufio.NewReaderSize(c.conn, NetworkReadBufferSize)
+
+		b, _ := bufReader.Peek(2048)
+		significant(c.peer.PeerIdent(), "processReceives() received data, first 2kB: %x", b)
+
 		decoder := gob.NewDecoder(bufReader)
 
 		c.conn.SetReadDeadline(time.Now().Add(NetworkDeadline))

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -574,7 +574,6 @@ func (c *Connection) parcelValidity(parcel Parcel) uint8 {
 		parcel.Trace("Connection.isValidParcel()-ParcelValid", "H")
 		return ParcelValid
 	}
-	return ParcelValid
 }
 func (c *Connection) handleParcelTypes(parcel Parcel) {
 	switch parcel.Header.Type {

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -49,6 +49,8 @@ var (
 	MinumumSharingQualityScore    int32  = 20          // if a peer's score is less than this we don't share them.
 	OnlySpecialPeers                     = false
 	NetworkDeadline                      = time.Duration(25000) * time.Millisecond
+	NetworkReadBufferSize                = 1024 // 1kB, size of the read buffer for data sent over the network
+	NetworkWriteBufferSize               = 1024 // 1kB, size of the write buffer for data sent over the network
 	NumberPeersToConnect                 = 8
 	MaxNumberIncommingConnections        = 150
 	MaxNumberOfRedialAttempts            = 15


### PR DESCRIPTION
Recreate encoder/decoder on each write/read:
- on writes: recreate the encoder and encode to a buffer first, then send encoded data in chunks over the socket
- on reads: whenever we receive some data, try to decode it using a new decoder, if we have an error when decoding and it is not a recognized network error, discard bad data, log and continue