### PR TITLE
SOF-514: parts mixup fix

### DIFF
--- a/p2p/controller.go
+++ b/p2p/controller.go
@@ -49,8 +49,9 @@ type Controller struct {
 	lastDiscoveryRequest       time.Time
 	NodeID                     uint64
 	lastStatusReport           time.Time
-	lastPeerRequest            time.Time // Last time we asked peers about the peers they know about.
-	specialPeersString         string    // configuration set special peers
+	lastPeerRequest            time.Time       // Last time we asked peers about the peers they know about.
+	specialPeersString         string          // configuration set special peers
+	partsAssembler             *PartsAssembler // a data structure that assembles full messages from received message parts
 }
 
 type ControllerInit struct {
@@ -200,6 +201,7 @@ func (c *Controller) Init(ci ControllerInit) *Controller {
 	c.specialPeersString = ci.SpecialPeers
 	c.lastDiscoveryRequest = time.Now() // Discovery does its own on startup.
 	c.lastConnectionMetricsUpdate = time.Now()
+	c.partsAssembler = new(PartsAssembler).Init()
 	discovery := new(Discovery).Init(ci.PeersFile, ci.SeedURL)
 	c.discovery = *discovery
 	// Set this to the past so we will do peer management almost right away after starting up.
@@ -503,6 +505,13 @@ func (c *Controller) handleParcelReceive(message interface{}, peerHash string, c
 		dot("&&m\n")
 		ApplicationMessagesRecieved++
 		BlockFreeChannelSend(c.FromNetwork, parcel)
+	case TypeMessagePart: // A part of the application message, handle by assembler and if we have the full message, send it on.
+		parcel.Trace("Controller.handleParcelReceive()-TypeMessagePart", "L")
+		assembled := c.partsAssembler.handlePart(parcel)
+		if assembled != nil {
+			ApplicationMessagesRecieved++
+			BlockFreeChannelSend(c.FromNetwork, *assembled)
+		}
 	case TypePeerRequest: // send a response to the connection over its connection.SendChannel
 		parcel.Trace("Controller.handleParcelReceive()-TypePeerRequest", "L")
 		dot("&&n\n")

--- a/p2p/parcel.go
+++ b/p2p/parcel.go
@@ -65,7 +65,7 @@ var CommandStrings = map[ParcelCommandType]string{
 }
 
 // MaxPayloadSize is the maximum bytes a message can be at the networking level.
-const MaxPayloadSize = 10000
+const MaxPayloadSize = 1000
 
 func NewParcel(network NetworkID, payload []byte) *Parcel {
 	header := new(ParcelHeader).Init(network)

--- a/p2p/parcel.go
+++ b/p2p/parcel.go
@@ -31,6 +31,7 @@ type ParcelHeader struct {
 	Crc32       uint32            // 4 bytes - data integrity hash (of the payload itself.)
 	PartNo      uint16            // 2 bytes - in case of multipart parcels, indicates which part this corresponds to, otherwise should be 0
 	PartsTotal  uint16            // 2 bytes - in case of multipart parcels, indicates the total number of parts that the receiver should expect
+	MessageID   uint64            // 8 bytes - unique ID of the message, in case of multipart messages, all parts will have the same ID
 	NodeID      uint64
 	PeerAddress string // address of the peer set by connection to know who sent message (for tracking source of other peers)
 	PeerPort    string // port of the peer , or we are listening on

--- a/p2p/parcel.go
+++ b/p2p/parcel.go
@@ -31,7 +31,6 @@ type ParcelHeader struct {
 	Crc32       uint32            // 4 bytes - data integrity hash (of the payload itself.)
 	PartNo      uint16            // 2 bytes - in case of multipart parcels, indicates which part this corresponds to, otherwise should be 0
 	PartsTotal  uint16            // 2 bytes - in case of multipart parcels, indicates the total number of parts that the receiver should expect
-	MessageID   uint64            // 8 bytes - unique ID of the message, in case of multipart messages, all parts will have the same ID
 	NodeID      uint64
 	PeerAddress string // address of the peer set by connection to know who sent message (for tracking source of other peers)
 	PeerPort    string // port of the peer , or we are listening on

--- a/p2p/parts_assembler.go
+++ b/p2p/parts_assembler.go
@@ -1,0 +1,86 @@
+// Copyright 2016 Factom Foundation
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package p2p
+
+import (
+	"time"
+)
+
+// maximum time we wait for a partial message to arrive, old entries are cleaned up only when new part arrives
+const MaxTimeWaitingForReassembly time.Duration = time.Second * 60 * 10
+
+type PartialMessage struct {
+	parts                  []*Parcel // array of message parts we've received so far
+	firstPartReceived      time.Time // a timestamp indicating when the first part was received
+	mostRecentPartReceived time.Time // a timestamp indicating when the mostRecent part was received
+}
+
+// PartsAssembler is responsible for assembling message parts into full messages
+type PartsAssembler struct {
+	messages map[uint64]*PartialMessage // a map of full message IDs to
+}
+
+// Initializes the assembler
+func (assembler *PartsAssembler) init() {
+	assembler.messages = make(map[uint64]*PartialMessage)
+}
+
+// Handles a single message part, returns either a fully assembled message or nil
+func (assembler *PartsAssembler) handlePart(parcel Parcel) *Parcel {
+	debug("PartsAssembler", "Handling message part %d %d/%d", parcel.Header.MessageID, parcel.Header.PartNo, parcel.Header.PartsTotal)
+	partial, exists := assembler.messages[parcel.Header.MessageID]
+
+	if !exists {
+		partial = createNewPartialMessage(parcel)
+		assembler.messages[parcel.Header.MessageID] = partial
+	}
+
+	partial.parts[parcel.Header.PartNo] = &parcel
+	partial.mostRecentPartReceived = time.Now()
+
+	fullParcel := tryReassemblingMessage(partial)
+	if fullParcel != nil {
+		delete(assembler.messages, parcel.Header.MessageID)
+		debug("PartsAssembler", "Fully assembled %d", parcel.Header.MessageID)
+	}
+
+	assembler.cleanupOldPartialMessages()
+
+	return fullParcel
+}
+
+// Checks existing partial messages and if there is anything older than MaxTimeWaitingForReassembly,
+// drops the partial message
+func (assembler *PartsAssembler) cleanupOldPartialMessages() {
+	for messageID, partial := range assembler.messages {
+		timeWaiting := time.Since(partial.mostRecentPartReceived)
+		timeSinceFirst := time.Since(partial.firstPartReceived)
+		if timeWaiting > MaxTimeWaitingForReassembly {
+			delete(assembler.messages, messageID)
+			note("PartsAssembler", "Dropping message %d after %s secs, time since first part: %s secs",
+				messageID, timeWaiting/time.Second, timeSinceFirst/time.Second)
+		}
+	}
+}
+
+// Creates a new PartialMessage from a given parcel
+func createNewPartialMessage(parcel Parcel) *PartialMessage {
+	partial := new(PartialMessage)
+	partial.parts = make([]*Parcel, parcel.Header.PartsTotal)
+	partial.firstPartReceived = time.Now()
+	return partial
+}
+
+// Tries reassembling a full Message from existing MessageParts, returns nil if
+// we don't have all the necessary parts yet
+func tryReassemblingMessage(partial *PartialMessage) *Parcel {
+	for _, part := range partial.parts {
+		if part == nil {
+			return nil
+		}
+	}
+
+	return ReassembleParcel(partial.parts)
+}

--- a/p2p/parts_assembler.go
+++ b/p2p/parts_assembler.go
@@ -41,12 +41,14 @@ func (assembler *PartsAssembler) handlePart(parcel Parcel) *Parcel {
 	partial.parts[parcel.Header.PartNo] = &parcel
 	partial.mostRecentPartReceived = time.Now()
 
+	// get an assembled parcel or nil if not yet ready
 	fullParcel := tryReassemblingMessage(partial)
 	if fullParcel != nil {
 		delete(assembler.messages, parcel.Header.AppHash)
 		debug("PartsAssembler", "Fully assembled %d", parcel.Header.AppHash)
 	}
 
+	// go through all partial messages and removes the old ones
 	assembler.cleanupOldPartialMessages()
 
 	return fullParcel

--- a/p2p/parts_assembler.go
+++ b/p2p/parts_assembler.go
@@ -23,8 +23,9 @@ type PartsAssembler struct {
 }
 
 // Initializes the assembler
-func (assembler *PartsAssembler) init() {
+func (assembler *PartsAssembler) Init() *PartsAssembler {
 	assembler.messages = make(map[uint64]*PartialMessage)
+	return assembler
 }
 
 // Handles a single message part, returns either a fully assembled message or nil


### PR DESCRIPTION
* Moves partial parcel assembly from connection to the controller (also separated the code to a separate file)
* Allows parts to arrive in random order, the final full message is assembled according to the AppHash from the original message
* If the expected parts stop arriving, cleans the existing entries after min 10 minutes (the check is performed every time a part arrives)
* Deacreases payload size from 10kB to 1kB to avoid gob errors