### PR TITLE
Don't continue to sync entries past a missing entry block.  Can goof …

### DIFF
--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -125,7 +125,7 @@ func (s *State) syncEntries(eights bool) {
 			// Dont have an eBlock?  Huh. We can go on, but we can't advance
 			if eBlock == nil {
 				alldone = false
-				continue
+				break
 			}
 
 			for _, entryhash := range eBlock.GetEntryHashes() {


### PR DESCRIPTION
…everything up.