### PR TITLE
change sleep on idle from 20 ms to 200 ms

### DIFF
--- a/state/validation.go
+++ b/state/validation.go
@@ -55,7 +55,7 @@ func (state *State) ValidatorLoop() {
 				state.JournalMessage(msg)
 				break loop
 			default: // No messages? Sleep for a bit
-				time.Sleep(20 * time.Millisecond)
+				time.Sleep(200 * time.Millisecond)
 			}
 		}
 


### PR DESCRIPTION
At 20 ms, we are burning too much CPU when idle for some tests.

No significant effect on response times and performance in my testing 

This value dictates how long we sleep when we provably have nothing to do.  Means we MIGHT waste 180 ms more time before we start processing a message, but will not delay processing a group of messages (i.e. heavy load will not be impacted).