### PR TITLE
Sof 606 into develop

### DIFF
--- a/controlPanel/searchDB.go
+++ b/controlPanel/searchDB.go
@@ -55,7 +55,7 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {
-			return false, ""
+			break
 		}
 		var fixed [32]byte
 		copy(fixed[:], hash[2:34])
@@ -67,7 +67,7 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {
-			return false, ""
+			break
 		}
 		var fixed [32]byte
 		copy(fixed[:], hash[2:34])

--- a/controlPanel/searchDB.go
+++ b/controlPanel/searchDB.go
@@ -51,7 +51,7 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 	switch searchitem[:2] {
 	case "EC":
 		if !primitives.ValidateECUserStr(searchitem) {
-			return false, ""
+			break
 		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {
@@ -63,7 +63,7 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 		return true, `{"Type":"EC","item":` + bal + "}"
 	case "FA":
 		if !primitives.ValidateFUserStr(searchitem) {
-			return false, ""
+			break
 		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {

--- a/controlPanel/searchDB.go
+++ b/controlPanel/searchDB.go
@@ -50,6 +50,9 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 	}
 	switch searchitem[:2] {
 	case "EC":
+		if !primitives.ValidateECUserStr(searchitem) {
+			return false, ""
+		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {
 			return false, ""
@@ -59,6 +62,9 @@ func searchDB(searchitem string, st state.State) (bool, string) {
 		bal := fmt.Sprintf("%d", st.FactoidState.GetECBalance(fixed))
 		return true, `{"Type":"EC","item":` + bal + "}"
 	case "FA":
+		if !primitives.ValidateFUserStr(searchitem) {
+			return false, ""
+		}
 		hash := base58.Decode(searchitem)
 		if len(hash) < 34 {
 			return false, ""


### PR DESCRIPTION
Fixed control panel showing invalid addresses as valid
Simple search 'FA3eQZMJBVpsTKRB19x9tC1wD3fzwSi4Q7Y5BW32rYw6P5yyWqfrExtracharacters' to see if it has been fixed. Also made it break out of the switch and go through the other searches if the address search fails. This is because EC and FA are valid hex, so there could be a case where an entry with "FA..." or "EC..." get's improperly rejected. Now it is fixed.