### PR TITLE
remove double processing of messages

### DIFF
--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -168,7 +168,7 @@ emptyLoop:
 	for room() {
 		select {
 		case msg := <-s.msgQueue:
-			process <- msg
+
 			if s.executeMsg(vm, msg) && !msg.IsPeer2Peer() {
 				msg.SendOut(s, msg)
 			}


### PR DESCRIPTION
You will note that we execute the message on line 171.  Then (if the message is in process) again on about line 196.  That can make us process a dbstate message twice.