### PR TITLE
set the EntryDBComplete flag to HighestSaved if all is synced

### DIFF
--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -239,6 +239,7 @@ func (s *State) GoSyncEntries() {
 		}
 		lastfirstmissing = firstMissing
 		if firstMissing < 0 {
+			s.EntryDBHeightComplete = s.GetHighestSavedBlk()
 			time.Sleep(60 * time.Second)
 		}
 


### PR DESCRIPTION
We took this assignment out, but we actually need it.