### PR TITLE
Added a lock around LevelDB Put()

### DIFF
--- a/database/leveldb/leveldb.go
+++ b/database/leveldb/leveldb.go
@@ -138,6 +138,9 @@ func (db *LevelDB) Put(bucket []byte, key []byte, data interfaces.BinaryMarshall
 }
 
 func (db *LevelDB) PutInBatch(records []interfaces.Record) error {
+	db.dbLock.Lock()
+	defer db.dbLock.Unlock()
+
 	if db.lbatch == nil {
 		db.lbatch = new(leveldb.Batch)
 	}

--- a/database/leveldb/leveldb.go
+++ b/database/leveldb/leveldb.go
@@ -112,6 +112,9 @@ func (db *LevelDB) Get(bucket []byte, key []byte, destination interfaces.BinaryM
 }
 
 func (db *LevelDB) Put(bucket []byte, key []byte, data interfaces.BinaryMarshallable) error {
+	db.dbLock.Lock()
+	defer db.dbLock.Unlock()
+
 	if db.lbatch == nil {
 		db.lbatch = new(leveldb.Batch)
 	}


### PR DESCRIPTION
There was no locking around LevelDB.Put(), and PutInBatch(). 

BoltDB has the locking