### PR TITLE
Added an API call to get transaction rate

### DIFF
--- a/common/interfaces/state.go
+++ b/common/interfaces/state.go
@@ -235,6 +235,12 @@ type IState interface {
 	// Returns false if we have seen an Entry Replay in the current period.
 	NoEntryYet(IHash, Timestamp) bool
 
+	// Calculates the transaction rate this node is seeing.
+	//		totalTPS	: Total transactions / total time node running
+	//		instantTPS	: Weighted transactions per second to get a better value for
+	//					  current transaction rate.
+	CalculateTransactionRate() (totalTPS float64, instantTPS float64)
+
 	//For ACK
 	GetACKStatus(hash IHash) (int, IHash, Timestamp, Timestamp, error)
 	FetchPaidFor(hash IHash) (IHash, error)

--- a/state/instrumentation.go
+++ b/state/instrumentation.go
@@ -65,6 +65,17 @@ var (
 		Name: "factomd_state_highest_completed",
 		Help: "Highest completed block, which may or may not be saved to the database",
 	})
+
+	// TPS
+	TotalTransactionPerSecond = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "factomd_state_txrate_total_tps",
+		Help: "Total transactions over life of node",
+	})
+
+	InstantTransactionPerSecond = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "factomd_state_txrate_instant_tps",
+		Help: "Total transactions over life of node weighted for last 3 seconds",
+	})
 )
 
 var registered bool = false
@@ -93,4 +104,8 @@ func RegisterPrometheus() {
 	prometheus.MustRegister(HighestKnown)
 	prometheus.MustRegister(HighestSaved)
 	prometheus.MustRegister(HighestCompleted)
+
+	// TPS
+	prometheus.MustRegister(TotalTransactionPerSecond)
+	prometheus.MustRegister(InstantTransactionPerSecond)
 }

--- a/state/state.go
+++ b/state/state.go
@@ -2042,11 +2042,13 @@ func (s *State) CalculateTransactionRate() (totalTPS float64, instantTPS float64
 	shorttime := time.Since(s.lasttime)
 	total := s.FactoidTrans + s.NewEntryChains + s.NewEntries
 	tps := float64(total) / float64(runtime.Seconds())
+	TotalTransactionPerSecond.Set(tps) // Prometheus
 	if shorttime > time.Second*3 {
 		delta := (s.FactoidTrans + s.NewEntryChains + s.NewEntries) - s.transCnt
 		s.tps = ((float64(delta) / float64(shorttime.Seconds())) + 2*s.tps) / 3
 		s.lasttime = time.Now()
-		s.transCnt = total // transactions accounted for
+		s.transCnt = total                     // transactions accounted for
+		InstantTransactionPerSecond.Set(s.tps) // Prometheus
 	}
 
 	return tps, s.tps

--- a/state/state.go
+++ b/state/state.go
@@ -1534,6 +1534,11 @@ func (s *State) UpdateState() (progress bool) {
 		s.CopyStateToControlPanel()
 	}
 
+	// Update our TPS every ~ 3 seconds at the earliest
+	if s.lasttime.Before(time.Now().Add(-3 * time.Second)) {
+		s.CalculateTransactionRate()
+	}
+
 	// check to see ig a holding queue list request has been made
 	s.fillHoldingMap()
 	s.fillAcksMap()
@@ -2029,6 +2034,24 @@ func (s *State) SetStringConsensus() {
 	s.serverPrt = str
 }
 
+// CalculateTransactionRate caculates how many transactions this node is processing
+//		totalTPS	: Transaction rate over life of node (totaltime / totaltrans)
+//		instantTPS	: Transaction rate weighted over last 3 seconds
+func (s *State) CalculateTransactionRate() (totalTPS float64, instantTPS float64) {
+	runtime := time.Since(s.starttime)
+	shorttime := time.Since(s.lasttime)
+	total := s.FactoidTrans + s.NewEntryChains + s.NewEntries
+	tps := float64(total) / float64(runtime.Seconds())
+	if shorttime > time.Second*3 {
+		delta := (s.FactoidTrans + s.NewEntryChains + s.NewEntries) - s.transCnt
+		s.tps = ((float64(delta) / float64(shorttime.Seconds())) + 2*s.tps) / 3
+		s.lasttime = time.Now()
+		s.transCnt = total // transactions accounted for
+	}
+
+	return tps, s.tps
+}
+
 func (s *State) SetStringQueues() {
 	vmi := -1
 	if s.Leader && s.LeaderVMIndex >= 0 {
@@ -2102,16 +2125,7 @@ func (s *State) SetStringQueues() {
 		dHeight = d.GetHeader().GetDBHeight()
 	}
 
-	runtime := time.Since(s.starttime)
-	shorttime := time.Since(s.lasttime)
-	total := s.FactoidTrans + s.NewEntryChains + s.NewEntries
-	tps := float64(total) / float64(runtime.Seconds())
-	if shorttime > time.Second*3 {
-		delta := (s.FactoidTrans + s.NewEntryChains + s.NewEntries) - s.transCnt
-		s.tps = ((float64(delta) / float64(shorttime.Seconds())) + 2*s.tps) / 3
-		s.lasttime = time.Now()
-		s.transCnt = total // transactions accounted for
-	}
+	totalTPS, instantTPS := s.CalculateTransactionRate()
 
 	str := fmt.Sprintf("%10s[%6x] %4s%4s %2d/%2d %2d.%01d%% %2d.%03d",
 		s.FactomNodeName,
@@ -2140,7 +2154,7 @@ func (s *State) SetStringQueues() {
 
 	trans := fmt.Sprintf("%d/%d/%d", s.FactoidTrans, s.NewEntryChains, s.NewEntries-s.NewEntryChains)
 	apis := fmt.Sprintf("%d/%d/%d", s.FCTSubmits, s.ECCommits, s.ECommits)
-	stps := fmt.Sprintf("%3.2f/%3.2f", tps, s.tps)
+	stps := fmt.Sprintf("%3.2f/%3.2f", totalTPS, instantTPS)
 	str = str + fmt.Sprintf(" %5d %5d %12s %15s %11s",
 		s.ResendCnt,
 		s.ExpireCnt,

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -6,6 +6,7 @@ package state_test
 
 import (
 	"testing"
+	"time"
 
 	"fmt"
 	//"github.com/FactomProject/factomd/common/constants"
@@ -14,6 +15,7 @@ import (
 	"github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
 	"github.com/FactomProject/factomd/util"
+	//. "github.com/FactomProject/factomd/state"
 )
 
 var _ = log.Print
@@ -94,6 +96,22 @@ func TestLoadAcksMap(t *testing.T) {
 	hque := state.LoadAcksMap()
 	if len(hque) != len(state.HoldingMap) {
 		t.Errorf("Error with Acks Map Length")
+	}
+
+}
+
+func TestCalculateTransactionRate(t *testing.T) {
+	s := testHelper.CreateAndPopulateTestState()
+	to, _ := s.CalculateTransactionRate()
+	time.Sleep(3 * time.Second)
+
+	s.FactoidTrans = 333
+	to2, i := s.CalculateTransactionRate()
+	if to >= to2 {
+		t.Errorf("Rate should be higher than %d, found %d", to, to2)
+	}
+	if i < 30 {
+		t.Errorf("Instant transaction rate should be > 30 (roughly), found %d", i)
 	}
 
 }

--- a/wsapi/wsapiStructs.go
+++ b/wsapi/wsapiStructs.go
@@ -113,6 +113,11 @@ type SendRawMessageResponse struct {
 	Message string `json:"message"`
 }
 
+type TransactionRateResponse struct {
+	TotalTransactionRate   float64 `json:"totaltxrate"`
+	InstantTransactionRate float64 `json:"instanttxrate"`
+}
+
 /*********************************************************************/
 
 type DBHead struct {

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -151,6 +151,8 @@ func HandleV2Request(state interfaces.IState, j *primitives.JSON2Request) (*prim
 		break
 	case "authorities":
 		resp, jsonError = HandleAuthorities(state, params)
+	case "tx-rate":
+		resp, jsonError = HandleV2TransactionRate(state, params)
 	default:
 		jsonError = NewMethodNotFoundError()
 		break
@@ -977,4 +979,15 @@ func HandleV2GetTranasction(state interfaces.IState, params interface{}) (interf
 	answer.IncludedInDirectoryBlockHeight = int64(dBlock.GetDatabaseHeight())
 
 	return answer, nil
+}
+
+func HandleV2TransactionRate(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
+	r := new(TransactionRateResponse)
+
+	// total	: Transaction rate over entire life of node
+	// instant	: Transaction rate weighted for last 3 seconds
+	total, instant := state.CalculateTransactionRate()
+	r.TotalTransactionRate = total
+	r.InstantTransactionRate = instant
+	return r, nil
 }

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -151,7 +151,7 @@ func HandleV2Request(state interfaces.IState, j *primitives.JSON2Request) (*prim
 		break
 	case "authorities":
 		resp, jsonError = HandleAuthorities(state, params)
-	case "tx-rate":
+	case "tps-rate":
 		resp, jsonError = HandleV2TransactionRate(state, params)
 	default:
 		jsonError = NewMethodNotFoundError()


### PR DESCRIPTION
Moved the calculation for transaction rate to a loop that is guarenteed
execution, and made it execute every ~3 seconds. This is a decent estimate
of transactions seen by the node