### PR TITLE
FD-78:  Limit dbstate requests and missing message requests when behind

### DIFF
--- a/common/messages/dbstateMissing.go
+++ b/common/messages/dbstateMissing.go
@@ -143,11 +143,11 @@ func (m *DBStateMissing) FollowerExecute(state interfaces.IState) {
 	// just a bit over 1 MB
 	l := len(state.InMsgQueue())
 	switch {
-	case l > 500:
+	case l > 200:
 		return
 	case l > 50 && end-start > 10:
 		end = start + 10
-	case l > 10 && end-start > 1:
+	case l > 50 && end-start > 1:
 		end = start + 1
 	case end-start > 200:
 		end = start + 200

--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -524,6 +524,15 @@ func SimControl(listenTo int) {
 						os.Stderr.WriteString("Take  " + f.State.FactomNodeName + " off the network\n")
 					}
 					f.State.SetNetStateOff(!v)
+
+					// Advance to the next node. Makes taking a number of nodes off or on line easier
+					fnodes[listenTo].State.SetOut(false)
+					listenTo++
+					if listenTo >= len(fnodes) {
+						listenTo = 0
+					}
+					fnodes[listenTo].State.SetOut(true)
+					os.Stderr.WriteString(fmt.Sprint("\r\nSwitching to Node ", listenTo, "\r\n"))
 				}
 
 			case 'y' == b[0]:

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -703,6 +703,11 @@ func (s *State) FollowerExecuteDataResponse(m interfaces.IMsg) {
 }
 
 func (s *State) FollowerExecuteMissingMsg(msg interfaces.IMsg) {
+	// Don't respond to missing messages if we are behind.
+	if len(s.inMsgQueue) > 100 {
+		return
+	}
+
 	m := msg.(*messages.MissingMsg)
 
 	pl := s.ProcessLists.Get(m.DBHeight)


### PR DESCRIPTION
Check the len of the InMsgQueue and don't respond with data when behind.