### PR TITLE
Instrument fix

### DIFF
--- a/common/entryBlock/eblockHeader_test.go
+++ b/common/entryBlock/eblockHeader_test.go
@@ -5,6 +5,7 @@
 package entryBlock_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"testing"
 
@@ -53,6 +54,50 @@ func TestEBlockHeaderMisc(t *testing.T) {
 	}
 	if h.GetEntryCount() != 2 {
 		t.Errorf("Invalid GetEntryCount - %v", h.GetEntryCount())
+	}
+
+	data, err := h.MarshalBinary()
+	if err != nil {
+		t.Error(err)
+	}
+
+	h2 := new(EBlockHeader)
+	nd, err := h2.UnmarshalBinaryData(data)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(nd) > 0 {
+		t.Errorf("Should be no bytes left, found %d", len(nd))
+	}
+
+	if h.String() != h2.String() {
+		t.Error("Strings should be the same")
+	}
+
+	j1, err := h.JSONString()
+	if err != nil {
+		t.Error(err)
+	}
+	j2, err := h2.JSONString()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if j1 != j2 {
+		t.Error("JsonStrings should be the same")
+	}
+
+	jb1, err := h.JSONByte()
+	if err != nil {
+		t.Error(err)
+	}
+	jb2, err := h2.JSONByte()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if bytes.Compare(jb1, jb2) != 0 {
+		t.Error("JsonBytes should be the same")
 	}
 }
 

--- a/engine/instrumentation.go
+++ b/engine/instrumentation.go
@@ -15,6 +15,11 @@ var (
 		Name: "factomd_state_broadcast_in_current",
 		Help: "Number of msgs in broadcastin queue.",
 	})
+
+	BroadCastInQueueDrop = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "factomd_state_broadcast_in_drop_total",
+		Help: "How many messages are dropped due to full queues",
+	})
 )
 
 var registered = false
@@ -29,4 +34,5 @@ func RegisterPrometheus() {
 
 	prometheus.MustRegister(RepeatMsgs)
 	prometheus.MustRegister(BroadInCastQueue)
+	prometheus.MustRegister(BroadCastInQueueDrop)
 }

--- a/engine/p2pProxy.go
+++ b/engine/p2pProxy.go
@@ -303,7 +303,7 @@ func (f *P2PProxy) ManageInChannel() {
 			removed := p2p.BlockFreeChannelSend(f.BroadcastIn, message)
 			BroadInCastQueue.Inc()
 			BroadInCastQueue.Add(float64(-1 * removed))
-			fmt.Println("Removed")
+			BroadCastInQueueDrop.Add(float64(removed))
 		default:
 			fmt.Printf("Garbage on f.FromNetwork. %+v", data)
 		}

--- a/engine/p2pProxy.go
+++ b/engine/p2pProxy.go
@@ -300,8 +300,10 @@ func (f *P2PProxy) ManageInChannel() {
 			parcel := data.(p2p.Parcel)
 			f.trace(parcel.Header.AppHash, parcel.Header.AppType, "P2PProxy.ManageInChannel()", "M")
 			message := factomMessage{Message: parcel.Payload, PeerHash: parcel.Header.TargetPeer, AppHash: parcel.Header.AppHash, AppType: parcel.Header.AppType}
-			p2p.BlockFreeChannelSend(f.BroadcastIn, message)
+			removed := p2p.BlockFreeChannelSend(f.BroadcastIn, message)
 			BroadInCastQueue.Inc()
+			BroadInCastQueue.Add(float64(-1 * removed))
+			fmt.Println("Removed")
 		default:
 			fmt.Printf("Garbage on f.FromNetwork. %+v", data)
 		}

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -17,7 +17,11 @@ import (
 
 // This file contains the global variables and utility functions for the p2p network operation.  The global variables and constants can be tweaked here.
 
-func BlockFreeChannelSend(channel chan interface{}, message interface{}) {
+// BlockFreeChannelSend will remove things from the queue to make room for new messages if the queue is full.
+// This prevents channel blocking on full.
+//		Returns: The number of elements cleared from the channel to make room
+func BlockFreeChannelSend(channel chan interface{}, message interface{}) int {
+	removed := 0
 	highWaterMark := int(float64(cap(channel)) * 0.95)
 	clen := len(channel)
 	switch {
@@ -25,6 +29,7 @@ func BlockFreeChannelSend(channel chan interface{}, message interface{}) {
 		str, _ := primitives.EncodeJSONString(message)
 		significant("protocol", "nonBlockingChanSend() - DROPPING MESSAGES. Channel is over 90 percent full! \n channel len: \n %d \n 90 percent: \n %d \n last message type: %v", len(channel), highWaterMark, str)
 		for highWaterMark <= len(channel) { // Clear out some messages
+			removed++
 			<-channel
 		}
 		fallthrough
@@ -34,6 +39,7 @@ func BlockFreeChannelSend(channel chan interface{}, message interface{}) {
 		default:
 		}
 	}
+	return removed
 }
 
 // Global variables for the p2p protocol


### PR DESCRIPTION
BroadCastIn Queue drops messages when it is full. These were not counted in the Prometheus, meaning the gauge will not return to 0 if messages are dropped. This was fixed, and another Prometheus counter was added to count the dropped messages