### PR TITLE
Fd 41 - Fixing Connection thrashing

### DIFF
--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -478,7 +478,7 @@ func (c *Connection) processReceives() {
 		for c.state == ConnectionOnline {
 			var message Parcel
 
-			c.conn.SetReadDeadline(time.Now().Add(NetworkDeadline))
+			// c.conn.SetReadDeadline(time.Now().Add(NetworkDeadline))
 			err := c.decoder.Decode(&message)
 			switch {
 			case nil == err:

--- a/p2p/protocol_test.go
+++ b/p2p/protocol_test.go
@@ -1,11 +1,34 @@
 package p2p_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/FactomProject/factomd/p2p"
 )
+
+func TestNetworkID(t *testing.T) {
+	var n NetworkID = MainNet
+	if n.String() != "MainNet" {
+		t.Errorf("Exp %s, got %s", "MainNet", n.String())
+	}
+
+	n = TestNet
+	if n.String() != "TestNet" {
+		t.Errorf("Exp %s, got %s", "TestNet", n.String())
+	}
+
+	n = LocalNet
+	if n.String() != "LocalNet" {
+		t.Errorf("Exp %s, got %s", "LocalNet", n.String())
+	}
+
+	n = 10
+	if n.String() != fmt.Sprintf("CustomNet ID: %x\n", 10) {
+		t.Errorf("Exp %s, got %s", fmt.Sprintf("CustomNet ID: %x\n", 10), n.String())
+	}
+}
 
 func TestBlockFreeChannelSend(t *testing.T) {
 	//BlockFreeChannelSend


### PR DESCRIPTION
The deadline is a race condition, stopping a read with partial data,
that error causes the connection to go offline. Receiving lots of
data will trigger this often.