### PR TITLE
Control Panel transactions fix

### DIFF
--- a/state/identityUtils.go
+++ b/state/identityUtils.go
@@ -372,7 +372,7 @@ func (e *Identity) UnmarshalBinaryData(p []byte) (newData []byte, err error) {
 	}
 
 	newData = buf.DeepCopyBytes()
-  
+
 	return
 }
 


### PR DESCRIPTION
Recent transactions should show the last 100 transactions. It was not doing so correctly as repeat transactions would be sent to the control panel, which the control panel is smart enough not to display them duplicate times, but would be satisfied with the 100, despite only being a few