### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 script:
         - go build -v
         - go test -v $(glide nv)
-        - travis_wait 30 $GOPATH/bin/goveralls -service=travis-ci -ignore=$(paste -sd, .coverignore)
+        - travis_wait 30 $GOPATH/bin/goveralls -service=travis-ci -ignore=$(paste -sd, .coverignore) -v
 notifications:
         slack:
                 secure: c8wuYqAHxEhIPBcCoM0IzoPQaBA5pqqi5jFRHsMu98VlHoKEiyjTGtNp2E7I5Y0jmxg1fEFZNsfRe0qC6X+XgcLuBCvsbFVeImtLP5sDZh3+FgfvQM+rh4VpgUENuIEpMCjXkJVzXAxEmWve3GLrhmdlP8PBxCbiwnUBe4kpbYeWZNcNXC4bZGxslNQBC/EHcrzW2zvRoMvBRhfPCbNea/XD/+6yK6tujOJ61HA9h3+Ys8FIAfyYy5XmNctKQKE6MOo6sh9Ou/OSlVM8JajG+FPDoYbk/MMnakAL41pQbZZjCYB9xI1y58zslTlv0FxmKsqml9qffb5veNpVYpdljOpegA3u4TGaLdTCpzJxibpuGVJWzUKHO2y59y54DPK275mOZCVL88SfKuUsFNER3Y6z0uZR3lLfsK5cmh5rPLyFCoPW9QvgT+nSUP/ueS629RgvyVWRXMpEin2P38v+4FqBrQMJ1fjAnecFxT9ztot0YyUsYqfzVnvaaQbXG6hAvCcc+iE5N0ObqqUhFGdiRa8IbsuOU1pL1uGeVSZXTvbb7Gh1TP1KPAb+vbeJygg6VYxHTJZIbF58yo7myqfprq6WBocYQh1C2/hhBfE4cE1su8vNZMex9cSk7fbK2WM9vYGe5g/rtWfx0EGK/16qOnOdCnrG7fnPq/R1REh8bvk=

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -24,7 +24,8 @@ var _ = log.Print
 var _ = util.ReadConfig
 
 func TestInit(t *testing.T) {
-	testHelper.CreateEmptyTestState()
+	s := testHelper.CreateEmptyTestState()
+	PrintState(s)
 }
 
 func TestSecretCode(t *testing.T) {


### PR DESCRIPTION
Travis will cancel the job if no response is given in 10min. Coveralls runs all of our unit tests, but silences the output. Out unit tests take > 10min, so it cancels our builds.

Adding -v will make coveralls print out to avoid the timeout