### PR TITLE
Time durations can be negative

### DIFF
--- a/engine/instrumentation.go
+++ b/engine/instrumentation.go
@@ -38,11 +38,11 @@ var (
 	})
 
 	// Send/Receive Times
-	TotalSendTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalSendTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_total_send_time",
 		Help: "Time spent sending (nanoseconds)",
 	})
-	TotalReceiveTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalReceiveTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_total_receive_time",
 		Help: "Time spent receiving (nanoseconds)",
 	})

--- a/state/instrumentation.go
+++ b/state/instrumentation.go
@@ -237,27 +237,27 @@ var (
 	})
 
 	// Durations
-	TotalReviewHoldingTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalReviewHoldingTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_review_holding_time",
 		Help: "Time spent in ReviewHolding()",
 	})
-	TotalProcessXReviewTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalProcessXReviewTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_process_xreview_time",
 		Help: "Time spent Processing XReview",
 	})
-	TotalProcessProcChanTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalProcessProcChanTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_process_proc_chan_time",
 		Help: "Time spent Processing Process Chan",
 	})
-	TotalEmptyLoopTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalEmptyLoopTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_empty_loop_time",
 		Help: "Time spent in empty loop",
 	})
-	TotalAckLoopTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalAckLoopTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_ack_loop_time",
 		Help: "Time spent in ack loop",
 	})
-	TotalExecuteMsgTime = prometheus.NewCounter(prometheus.CounterOpts{
+	TotalExecuteMsgTime = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "factomd_state_execute_msg_time",
 		Help: "Time spent in executeMsg",
 	})

--- a/state/queues_test.go
+++ b/state/queues_test.go
@@ -12,10 +12,27 @@ import (
 
 var _ = fmt.Println
 
+func TestTimeSinceNegative(t *testing.T) {
+	RegisterPrometheus()
+	RegisterPrometheus()
+	var p time.Duration
+	defer func() {
+		if r := recover(); r != nil {
+			t.Error("Test paniced")
+		}
+	}()
+
+	for i := 0; i < 100000; i++ {
+		n := time.Now()
+		p = time.Since(n)
+
+		TotalExecuteMsgTime.Add(float64(p.Nanoseconds()))
+	}
+}
+
 func TestQueues(t *testing.T) {
 	var _, _ = NewInMsgQueue(0), NewNetOutMsgQueue(0)
-	RegisterPrometheus()
-	RegisterPrometheus()
+
 	channel := make(chan interfaces.IMsg, 1000)
 	general := GeneralMSGQueue(channel)
 	inmsg := InMsgMSGQueue(channel)


### PR DESCRIPTION
 float64(time.Since().Nanoseconds) does not guarentee positive results
To combat this, use gauges instead of counters in prometheus to avoid panics