### PR TITLE
FD-334  Optimization 

### DIFF
--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -31,10 +31,10 @@ type Ack struct {
 
 	Signature interfaces.IFullSignature
 	//Not marshalled
-	hash        interfaces.IHash
-	authvalid   bool
-	Response    bool // A response to a missing data request
-	BalanceHash interfaces.IHash
+	hash         interfaces.IHash
+	authvalid    bool
+	Response     bool // A response to a missing data request
+	BalanceHash  interfaces.IHash
 	marshalCache []byte
 }
 

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -35,6 +35,7 @@ type Ack struct {
 	authvalid   bool
 	Response    bool // A response to a missing data request
 	BalanceHash interfaces.IHash
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*Ack)(nil)
@@ -310,6 +311,11 @@ func (m *Ack) MarshalForSignature() ([]byte, error) {
 }
 
 func (m *Ack) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	resp, err := m.MarshalForSignature()
 	if err != nil {
 		return nil, err

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -161,6 +161,9 @@ func (m *Ack) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 			err = fmt.Errorf("Error unmarshalling: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+	
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -162,8 +162,6 @@ func (m *Ack) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 		}
 	}()
 
-	m.marshalCache = data
-	
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -239,6 +237,9 @@ func (m *Ack) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 			return nil, err
 		}
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
+
 	return
 }
 

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -238,7 +238,7 @@ func (m *Ack) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 		}
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return
 }

--- a/common/messages/commitChain.go
+++ b/common/messages/commitChain.go
@@ -191,7 +191,7 @@ func (m *CommitChainMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		}
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/commitChain.go
+++ b/common/messages/commitChain.go
@@ -26,6 +26,7 @@ type CommitChainMsg struct {
 	// Not marshaled... Just used by the leader
 	count    int
 	validsig bool
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*CommitChainMsg)(nil)
@@ -168,6 +169,9 @@ func (m *CommitChainMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 			err = fmt.Errorf("Error unmarshalling Commit Chain Message: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -212,6 +216,11 @@ func (m *CommitChainMsg) MarshalForSignature() (data []byte, err error) {
 }
 
 func (m *CommitChainMsg) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	resp, err := m.MarshalForSignature()
 	if err != nil {
 		return nil, err

--- a/common/messages/commitChain.go
+++ b/common/messages/commitChain.go
@@ -24,8 +24,8 @@ type CommitChainMsg struct {
 	Signature interfaces.IFullSignature
 
 	// Not marshaled... Just used by the leader
-	count    int
-	validsig bool
+	count        int
+	validsig     bool
 	marshalCache []byte
 }
 

--- a/common/messages/commitChain.go
+++ b/common/messages/commitChain.go
@@ -170,8 +170,6 @@ func (m *CommitChainMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -192,6 +190,8 @@ func (m *CommitChainMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 			return nil, err
 		}
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/commitEntry.go
+++ b/common/messages/commitEntry.go
@@ -30,6 +30,7 @@ type CommitEntryMsg struct {
 	// Not marshaled... Just used by the leader
 	count    int
 	validsig bool
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*CommitEntryMsg)(nil)
@@ -126,6 +127,9 @@ func (m *CommitEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 			err = fmt.Errorf("Error unmarshalling Commit entry Message: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -170,6 +174,11 @@ func (m *CommitEntryMsg) MarshalForSignature() (data []byte, err error) {
 }
 
 func (m *CommitEntryMsg) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	resp, err := m.MarshalForSignature()
 	if err != nil {
 		return nil, err

--- a/common/messages/commitEntry.go
+++ b/common/messages/commitEntry.go
@@ -149,7 +149,7 @@ func (m *CommitEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		}
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/commitEntry.go
+++ b/common/messages/commitEntry.go
@@ -28,8 +28,8 @@ type CommitEntryMsg struct {
 	hash interfaces.IHash
 
 	// Not marshaled... Just used by the leader
-	count    int
-	validsig bool
+	count        int
+	validsig     bool
 	marshalCache []byte
 }
 

--- a/common/messages/commitEntry.go
+++ b/common/messages/commitEntry.go
@@ -128,8 +128,6 @@ func (m *CommitEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -150,6 +148,8 @@ func (m *CommitEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 			return nil, err
 		}
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/directoryBlockSignature.go
+++ b/common/messages/directoryBlockSignature.go
@@ -242,8 +242,6 @@ func (m *DirectoryBlockSignature) UnmarshalBinaryData(data []byte) (newData []by
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -299,6 +297,8 @@ func (m *DirectoryBlockSignature) UnmarshalBinaryData(data []byte) (newData []by
 		}
 		m.Signature = sig
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return nil, nil
 }

--- a/common/messages/directoryBlockSignature.go
+++ b/common/messages/directoryBlockSignature.go
@@ -298,7 +298,7 @@ func (m *DirectoryBlockSignature) UnmarshalBinaryData(data []byte) (newData []by
 		m.Signature = sig
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return nil, nil
 }

--- a/common/messages/directoryBlockSignature.go
+++ b/common/messages/directoryBlockSignature.go
@@ -38,6 +38,7 @@ type DirectoryBlockSignature struct {
 	//Not marshalled
 	Matches bool
 	hash    interfaces.IHash
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*DirectoryBlockSignature)(nil)
@@ -241,6 +242,8 @@ func (m *DirectoryBlockSignature) UnmarshalBinaryData(data []byte) (newData []by
 		}
 	}()
 
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -361,6 +364,11 @@ func (m *DirectoryBlockSignature) MarshalForSignature() ([]byte, error) {
 }
 
 func (m *DirectoryBlockSignature) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	var sig interfaces.IFullSignature
 	resp, err := m.MarshalForSignature()
 	if err == nil {

--- a/common/messages/directoryBlockSignature.go
+++ b/common/messages/directoryBlockSignature.go
@@ -36,8 +36,8 @@ type DirectoryBlockSignature struct {
 	SysHash     interfaces.IHash
 
 	//Not marshalled
-	Matches bool
-	hash    interfaces.IHash
+	Matches      bool
+	hash         interfaces.IHash
 	marshalCache []byte
 }
 

--- a/common/messages/eom.go
+++ b/common/messages/eom.go
@@ -33,8 +33,8 @@ type EOM struct {
 	FactoidVM bool
 
 	//Not marshalled
-	hash       interfaces.IHash
-	MarkerSent bool // If we have set EOM markers on blocks like Factoid blocks and such.
+	hash         interfaces.IHash
+	MarkerSent   bool // If we have set EOM markers on blocks like Factoid blocks and such.
 	marshalCache []byte
 }
 

--- a/common/messages/eom.go
+++ b/common/messages/eom.go
@@ -35,6 +35,7 @@ type EOM struct {
 	//Not marshalled
 	hash       interfaces.IHash
 	MarkerSent bool // If we have set EOM markers on blocks like Factoid blocks and such.
+	marshalCache []byte
 }
 
 //var _ interfaces.IConfirmation = (*EOM)(nil)
@@ -203,6 +204,9 @@ func (m *EOM) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 			err = fmt.Errorf("Error unmarshalling EOM message: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -281,6 +285,11 @@ func (m *EOM) MarshalForSignature() (data []byte, err error) {
 }
 
 func (m *EOM) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	var buf primitives.Buffer
 	resp, err := m.MarshalForSignature()
 	if err != nil {

--- a/common/messages/eom.go
+++ b/common/messages/eom.go
@@ -205,8 +205,6 @@ func (m *EOM) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -250,6 +248,8 @@ func (m *EOM) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 		}
 		m.Signature = sig
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return
 }

--- a/common/messages/eom.go
+++ b/common/messages/eom.go
@@ -249,7 +249,7 @@ func (m *EOM) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
 		m.Signature = sig
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return
 }

--- a/common/messages/factoidTransaction.go
+++ b/common/messages/factoidTransaction.go
@@ -167,8 +167,6 @@ func (m *FactoidTransaction) UnmarshalBinaryData(data []byte) (newData []byte, e
 		}
 	}()
 
-	m.marshalCache = data
-
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
 	}
@@ -176,6 +174,9 @@ func (m *FactoidTransaction) UnmarshalBinaryData(data []byte) (newData []byte, e
 
 	m.Transaction = new(factoid.Transaction)
 	newData, err = m.Transaction.UnmarshalBinaryData(newData)
+
+	m.marshalCache = data[: len(data)-len(newData)]
+
 	return newData, err
 }
 

--- a/common/messages/factoidTransaction.go
+++ b/common/messages/factoidTransaction.go
@@ -23,8 +23,8 @@ type FactoidTransaction struct {
 	//No signature!
 
 	//Not marshalled
-	hash      interfaces.IHash
-	processed bool
+	hash         interfaces.IHash
+	processed    bool
 	marshalCache []byte
 }
 

--- a/common/messages/factoidTransaction.go
+++ b/common/messages/factoidTransaction.go
@@ -25,6 +25,7 @@ type FactoidTransaction struct {
 	//Not marshalled
 	hash      interfaces.IHash
 	processed bool
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*FactoidTransaction)(nil)
@@ -165,6 +166,9 @@ func (m *FactoidTransaction) UnmarshalBinaryData(data []byte) (newData []byte, e
 			err = fmt.Errorf("Error unmarshalling Factoid: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
 	}
@@ -181,6 +185,11 @@ func (m *FactoidTransaction) UnmarshalBinary(data []byte) error {
 }
 
 func (m *FactoidTransaction) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	var buf primitives.Buffer
 	buf.Write([]byte{m.Type()})
 

--- a/common/messages/factoidTransaction.go
+++ b/common/messages/factoidTransaction.go
@@ -175,7 +175,7 @@ func (m *FactoidTransaction) UnmarshalBinaryData(data []byte) (newData []byte, e
 	m.Transaction = new(factoid.Transaction)
 	newData, err = m.Transaction.UnmarshalBinaryData(newData)
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return newData, err
 }

--- a/common/messages/heartbeat.go
+++ b/common/messages/heartbeat.go
@@ -157,7 +157,7 @@ func (m *Heartbeat) UnmarshalBinaryData(data []byte) (newData []byte, err error)
 		m.Signature = sig
 	}
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return nil, nil
 }

--- a/common/messages/heartbeat.go
+++ b/common/messages/heartbeat.go
@@ -118,8 +118,6 @@ func (m *Heartbeat) UnmarshalBinaryData(data []byte) (newData []byte, err error)
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -158,6 +156,8 @@ func (m *Heartbeat) UnmarshalBinaryData(data []byte) (newData []byte, err error)
 		}
 		m.Signature = sig
 	}
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return nil, nil
 }

--- a/common/messages/heartbeat.go
+++ b/common/messages/heartbeat.go
@@ -27,8 +27,8 @@ type Heartbeat struct {
 	Signature interfaces.IFullSignature
 
 	//Not marshalled
-	hash     interfaces.IHash
-	sigvalid bool
+	hash         interfaces.IHash
+	sigvalid     bool
 	marshalCache []byte
 }
 

--- a/common/messages/heartbeat.go
+++ b/common/messages/heartbeat.go
@@ -29,6 +29,7 @@ type Heartbeat struct {
 	//Not marshalled
 	hash     interfaces.IHash
 	sigvalid bool
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*Heartbeat)(nil)
@@ -116,6 +117,9 @@ func (m *Heartbeat) UnmarshalBinaryData(data []byte) (newData []byte, err error)
 			err = fmt.Errorf("Error unmarshalling HeartBeat: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("Invalid Message type")
@@ -195,6 +199,11 @@ func (m *Heartbeat) MarshalForSignature() (data []byte, err error) {
 }
 
 func (m *Heartbeat) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	resp, err := m.MarshalForSignature()
 	if err != nil {
 		return nil, err

--- a/common/messages/revealEntry.go
+++ b/common/messages/revealEntry.go
@@ -221,7 +221,7 @@ func (m *RevealEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 	}
 	m.Entry = e
 
-	m.marshalCache = data[: len(data)-len(newData)]
+	m.marshalCache = data[:len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/revealEntry.go
+++ b/common/messages/revealEntry.go
@@ -201,8 +201,6 @@ func (m *RevealEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		}
 	}()
 
-	m.marshalCache = data
-
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("%s", "Invalid Message type")
@@ -222,6 +220,8 @@ func (m *RevealEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 		return nil, err
 	}
 	m.Entry = e
+
+	m.marshalCache = data[: len(data)-len(newData)]
 
 	return newData, nil
 }

--- a/common/messages/revealEntry.go
+++ b/common/messages/revealEntry.go
@@ -26,11 +26,11 @@ type RevealEntryMsg struct {
 	//No signature!
 
 	//Not marshalled
-	hash        interfaces.IHash
-	chainIDHash interfaces.IHash
-	IsEntry     bool
-	CommitChain *CommitChainMsg
-	commitEntry *CommitEntryMsg
+	hash         interfaces.IHash
+	chainIDHash  interfaces.IHash
+	IsEntry      bool
+	CommitChain  *CommitChainMsg
+	commitEntry  *CommitEntryMsg
 	marshalCache []byte
 }
 

--- a/common/messages/revealEntry.go
+++ b/common/messages/revealEntry.go
@@ -31,6 +31,7 @@ type RevealEntryMsg struct {
 	IsEntry     bool
 	CommitChain *CommitChainMsg
 	commitEntry *CommitEntryMsg
+	marshalCache []byte
 }
 
 var _ interfaces.IMsg = (*RevealEntryMsg)(nil)
@@ -199,6 +200,9 @@ func (m *RevealEntryMsg) UnmarshalBinaryData(data []byte) (newData []byte, err e
 			err = fmt.Errorf("Error unmarshalling: %v", r)
 		}
 	}()
+
+	m.marshalCache = data
+
 	newData = data
 	if newData[0] != m.Type() {
 		return nil, fmt.Errorf("%s", "Invalid Message type")
@@ -228,6 +232,11 @@ func (m *RevealEntryMsg) UnmarshalBinary(data []byte) error {
 }
 
 func (m *RevealEntryMsg) MarshalBinary() (data []byte, err error) {
+
+	if m.marshalCache != nil {
+		return m.marshalCache, nil
+	}
+
 	var buf primitives.Buffer
 
 	binary.Write(&buf, binary.BigEndian, m.Type())

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -56,8 +56,7 @@ func randomIPendingEntry(nilSpot int) *interfaces.IPendingEntry {
 	return entry
 }
 
-
 func TestTrace(t *testing.T) {
-       Trace()
-       Trace("one string to print")
+	Trace()
+	Trace("one string to print")
 }


### PR DESCRIPTION
Don't need to marshal messages if we keep their unmarshaled form when we receive them from the network.  Saves Garbage collection, and repeated marshal operations. 