### PR TITLE
Refactor creating process lists on Get

### DIFF
--- a/state/processListManager_test.go
+++ b/state/processListManager_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 Factom Foundation
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE file.
+
+package state_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/FactomProject/factomd/state"
+	"github.com/FactomProject/factomd/testHelper"
+)
+
+func TestGettingFromProcessLists(t *testing.T) {
+	state := testHelper.CreateEmptyTestState()
+	plls := NewProcessLists(state)
+
+	pl := plls.Get(0)
+	assertPllsLength(t, plls, 1)
+	assertPlExists(t, pl)
+
+	pl = plls.Get(1)
+	assertPllsLength(t, plls, 2)
+	assertPlExists(t, pl)
+
+	pl = plls.Get(10)
+	assertPllsLength(t, plls, 11)
+	assertPlExists(t, pl)
+
+	pl = plls.Get(199)
+	assertPllsLength(t, plls, 200)
+	assertPlExists(t, pl)
+
+	pl = plls.Get(210)
+	assertPllsLength(t, plls, 211)
+	assertPlDoesNotExist(t, pl)
+
+}
+
+func assertPlExists(t *testing.T, item *ProcessList) {
+	if item == nil {
+		t.Error(fmt.Sprintf("Item %v should exists, but got nil", item))
+	}
+}
+
+func assertPlDoesNotExist(t *testing.T, item *ProcessList) {
+	if item != nil {
+		t.Error(fmt.Sprintf("Item should be nil, but got %v", item))
+	}
+}
+
+func assertPllsLength(t *testing.T, plls *ProcessLists, expected int) {
+	length := len(plls.Lists)
+	if length != expected {
+		t.Error(fmt.Sprintf("Length should be %v but got %v", expected, length))
+	}
+}


### PR DESCRIPTION
Avoids recursively looping over the list of process lists when it is not necessary.