### PR TITLE
exclusive_in flag

### DIFF
--- a/common/globals/globals.go
+++ b/common/globals/globals.go
@@ -28,6 +28,7 @@ type FactomParams struct {
 	FaultTimeout             int
 	RuntimeLog               bool
 	Exclusive                bool
+	ExclusiveIn              bool
 	Prefix                   string
 	Rotate                   bool
 	TimeOffset               int

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -255,6 +255,7 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 	os.Stderr.WriteString(fmt.Sprintf("%20s \"%s\"\n", "database for clones", p.CloneDB))
 	os.Stderr.WriteString(fmt.Sprintf("%20s \"%s\"\n", "peers", p.Peers))
 	os.Stderr.WriteString(fmt.Sprintf("%20s \"%t\"\n", "exclusive", p.Exclusive))
+	os.Stderr.WriteString(fmt.Sprintf("%20s \"%t\"\n", "exclusive_in", p.ExclusiveIn))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %d\n", "block time", p.BlkTime))
 	//os.Stderr.WriteString(fmt.Sprintf("%20s %d\n", "faultTimeout", p.FaultTimeout)) // TODO old fault timeout mechanism to be removed
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "runtimeLog", p.RuntimeLog))

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -351,6 +351,7 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 			PeersFile:                s.PeersFile,
 			Network:                  networkID,
 			Exclusive:                p.Exclusive,
+			ExclusiveIn:              p.ExclusiveIn,
 			SeedURL:                  seedURL,
 			SpecialPeers:             specialPeers,
 			ConnectionMetricsChannel: connectionMetricsChannel,

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -302,24 +302,24 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 
 	// Start the P2P network
 	var networkID p2p.NetworkID
-	var seedURL, networkPort, specialPeers string
+	var seedURL, networkPort, configPeers string
 	switch s.Network {
 	case "MAIN", "main":
 		networkID = p2p.MainNet
 		seedURL = s.MainSeedURL
 		networkPort = s.MainNetworkPort
-		specialPeers = s.MainSpecialPeers
+		configPeers = s.MainSpecialPeers
 		s.DirectoryBlockInSeconds = 600
 	case "TEST", "test":
 		networkID = p2p.TestNet
 		seedURL = s.TestSeedURL
 		networkPort = s.TestNetworkPort
-		specialPeers = s.TestSpecialPeers
+		configPeers = s.TestSpecialPeers
 	case "LOCAL", "local":
 		networkID = p2p.LocalNet
 		seedURL = s.LocalSeedURL
 		networkPort = s.LocalNetworkPort
-		specialPeers = s.LocalSpecialPeers
+		configPeers = s.LocalSpecialPeers
 	case "CUSTOM", "custom":
 		if bytes.Compare(p.CustomNet, []byte("\xe3\xb0\xc4\x42")) == 0 {
 			panic("Please specify a custom network with -customnet=<something unique here>")
@@ -331,7 +331,7 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 		}
 		seedURL = s.CustomSeedURL
 		networkPort = s.CustomNetworkPort
-		specialPeers = s.CustomSpecialPeers
+		configPeers = s.CustomSpecialPeers
 	default:
 		panic("Invalid Network choice in Config File or command line. Choose MAIN, TEST, LOCAL, or CUSTOM")
 	}
@@ -353,7 +353,8 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 			Exclusive:                p.Exclusive,
 			ExclusiveIn:              p.ExclusiveIn,
 			SeedURL:                  seedURL,
-			SpecialPeers:             specialPeers,
+			ConfigPeers:              configPeers,
+			CmdLinePeers:             p.Peers,
 			ConnectionMetricsChannel: connectionMetricsChannel,
 		}
 		p2pNetwork = new(p2p.Controller).Init(ci)
@@ -365,8 +366,6 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 
 		fnodes[0].Peers = append(fnodes[0].Peers, p2pProxy)
 		p2pProxy.StartProxy()
-		// Command line peers lets us manually set special peers
-		p2pNetwork.DialSpecialPeersString(p.Peers)
 
 		go networkHousekeeping() // This goroutine executes once a second to keep the proxy apprised of the network status.
 	}

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -44,6 +44,7 @@ func ParseCmdLine(args []string) *FactomParams {
 	//	faultTimeoutPtr := flag.Int("faulttimeout", 99999, "Seconds before considering Federated servers at-fault. Default is 30.")
 	runtimeLogPtr := flag.Bool("runtimeLog", false, "If true, maintain runtime logs of messages passed.")
 	exclusivePtr := flag.Bool("exclusive", false, "If true, we only dial out to special/trusted peers.")
+	exclusiveInPtr := flag.Bool("exclusive_in", false, "If true, we only dial out to special/trusted peers and no incoming connections are accepted.")
 	PrefixNodePtr := flag.String("prefix", "", "Prefix the Factom Node Names with this value; used to create leaderless networks.")
 	RotatePtr := flag.Bool("rotate", false, "If true, responsibility is owned by one leader, and Rotated over the leaders.")
 	TimeOffsetPtr := flag.Int("timedelta", 0, "Maximum timeDelta in milliseconds to offset each node.  Simulates deltas in system clocks over a network.")
@@ -117,6 +118,7 @@ func ParseCmdLine(args []string) *FactomParams {
 	//	p.FaultTimeout = *faultTimeoutPtr
 	p.RuntimeLog = *runtimeLogPtr
 	p.Exclusive = *exclusivePtr
+	p.ExclusiveIn = *exclusiveInPtr
 	p.Prefix = *PrefixNodePtr
 	p.Rotate = *RotatePtr
 	p.TimeOffset = *TimeOffsetPtr

--- a/netTest/NetworkTest.go
+++ b/netTest/NetworkTest.go
@@ -93,7 +93,7 @@ func InitNetwork() {
 		Exclusive:                exclusive,
 		ExclusiveIn:              exclusiveIn,
 		SeedURL:                  "",
-		SpecialPeers:             peers,
+		ConfigPeers:              peers,
 		ConnectionMetricsChannel: connectionMetricsChannel,
 	}
 	p2pNetwork := new(p2p.Controller).Init(ci)
@@ -104,8 +104,6 @@ func InitNetwork() {
 	p2pProxy.ToNetwork = p2pNetwork.ToNetwork
 
 	p2pProxy.StartProxy()
-	// Command line peers lets us manually set special peers
-	p2pNetwork.DialSpecialPeersString("")
 }
 
 var cntreq int32

--- a/netTest/NetworkTest.go
+++ b/netTest/NetworkTest.go
@@ -49,6 +49,7 @@ func InitNetwork() {
 	logportPtr := flag.String("logPort", "6060", "Port for the profiler")
 	peersPtr := flag.String("peers", "", "Array of peer addresses. ")
 	exclusivePtr := flag.Bool("exclusive", false, "If true, we only dial out to special/trusted peers.")
+	exclusiveInPtr := flag.Bool("exclusive_in", false, "If true, we only dial out to special/trusted peers and disallow all incoming connections.")
 	deadlinePtr := flag.Int64("deadline", 1, "Deadline for Reads and Writes to conn.")
 	p2pPtr := flag.Bool("p2p", false, "Test p2p messages (default to false)")
 	numStampsPtr := flag.Int("numstamps", 1, "Number of timestamps per reply on p2p test. (makes messages big)")
@@ -63,6 +64,7 @@ func InitNetwork() {
 	port := *networkPortOverridePtr
 	peers := *peersPtr
 	exclusive := *exclusivePtr
+	exclusiveIn := *exclusiveInPtr
 	logPort = *logportPtr
 	p2p.NetworkDeadline = time.Duration(*deadlinePtr) * time.Millisecond
 	isp2p = *p2pPtr
@@ -78,6 +80,7 @@ func InitNetwork() {
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %s\n", "networkPort", port))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %s\n", "peers", peers))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "exclusive", exclusive))
+	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "exclusiveIn", exclusiveIn))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "deadline", p2p.NetworkDeadline.Seconds()))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "p2p", isp2p))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %dk\n\n", "size", size/1024))
@@ -88,6 +91,7 @@ func InitNetwork() {
 		PeersFile:                "peers.json",
 		Network:                  1,
 		Exclusive:                exclusive,
+		ExclusiveIn:              exclusiveIn,
 		SeedURL:                  "",
 		SpecialPeers:             peers,
 		ConnectionMetricsChannel: connectionMetricsChannel,

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -145,6 +145,14 @@ func (p *Peer) LocationFromAddress() (location uint32) {
 	return location
 }
 
+func (p *Peer) IsSamePeerAs(netAddress net.Addr) bool {
+	address, _, err := net.SplitHostPort(netAddress.String())
+	if err != nil {
+		return false
+	}
+	return address == p.Address
+}
+
 // merit increases a peers reputation
 func (p *Peer) merit() {
 	if 2147483000 > p.QualityScore {

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -52,7 +52,8 @@ var (
 	MinumumQualityScore          int32  = -200        // if a peer's score is less than this we ignore them.
 	BannedQualityScore           int32  = -2147000000 // Used to ban a peer
 	MinumumSharingQualityScore   int32  = 20          // if a peer's score is less than this we don't share them.
-	OnlySpecialPeers                    = false
+	OnlySpecialPeers                    = false       // dial out to special peers only
+	AcceptIncomingConnections           = true        // allow incoming connections from peers
 	NetworkDeadline                     = time.Duration(30) * time.Second
 	NumberPeersToConnect                = 32
 	NumberPeersToBroadcast              = 8 // This gets overwritten by command line flag!

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -53,7 +53,7 @@ var (
 	BannedQualityScore           int32  = -2147000000 // Used to ban a peer
 	MinumumSharingQualityScore   int32  = 20          // if a peer's score is less than this we don't share them.
 	OnlySpecialPeers                    = false       // dial out to special peers only
-	AcceptIncomingConnections           = true        // allow incoming connections from peers
+	AllowUnknownIncomingPeers           = true        // allow incoming connections from peers that are not in the special peer list
 	NetworkDeadline                     = time.Duration(30) * time.Second
 	NumberPeersToConnect                = 32
 	NumberPeersToBroadcast              = 8 // This gets overwritten by command line flag!


### PR DESCRIPTION
Allows passing `exclusive_in` flag at startup, which:
 - works the same way as `exclusive` flag, i.e. dials out only to special peers (passed via config or the cmd line)
 - restricts the peers that can connect to a node only to the peers that are in the special peer list