### PR TITLE
Fix errors after gob enc/dec were reinintialized (communitynet-m3)

### DIFF
--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -8,6 +8,7 @@ import (
 	"encoding/gob"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"net"
 	"os"
 	"time"
@@ -356,6 +357,11 @@ func (c *Connection) goOnline() {
 func (c *Connection) goOffline() {
 	c.logger.Debug("Going offline")
 	p2pConnectionOfflineCall.Inc()
+	if nil != c.conn {
+		defer c.conn.Close()
+	}
+	c.decoder = nil
+	c.encoder = nil
 	c.state = ConnectionOffline
 	c.attempts = 0
 	c.peer.demerit()
@@ -488,17 +494,18 @@ func (c *Connection) processReceives() {
 		for c.state == ConnectionOnline {
 			var message Parcel
 
-			// c.conn.SetReadDeadline(time.Now().Add(NetworkDeadline))
-			err := c.decoder.Decode(&message)
-			switch {
-			case nil == err:
+			result := c.decoder.Decode(&message)
+			switch result {
+			case io.EOF: // nothing to decode
+				continue
+			case nil: // successfully decoded
 				c.metrics.BytesReceived += message.Header.Length
 				c.metrics.MessagesReceived += 1
 				message.Header.PeerAddress = c.peer.Address
 				c.ReceiveParcel <- &message
 				c.TimeLastpacket = time.Now()
-			default:
-				c.Errors <- err
+			default: // error
+				c.Errors <- result
 			}
 		}
 		// If not online, give some time up to handle states that are not online, closed, or shuttingdown.


### PR DESCRIPTION
Same as #451 but against the `communitynet-m3` branch

Fixes two separate issues:

* When the connection was going offline due to some error, it was
possible in some cases for the goOnline function to reinitialize gob
encoder/decoder without restarting the TCP/IP connection. The new
decoder would start reading data from the old connection, but due to
buffered reads the old decoder might have left the data in the
connection in the middle on the message. This caused an error which
again caused the connection to go offline and online and repeat the
problem, so as a result the whole connection was stuck in an infinite
error loop. This change ensures that the connection is closed when going
offline.

* The gob.Decoder.Decode function returns io.EOF when there is nothing
to read. This wasn't handled properly, so it was treated as an error (it
might have been the original cause for the previous problem).  This
change ignores the io.EOF result from the decoder.