### PR TITLE
FD-472

### DIFF
--- a/state/stateDisplay.go
+++ b/state/stateDisplay.go
@@ -116,15 +116,9 @@ func DeepStateDisplayCopyDifference(s *State, prev *DisplayState) (*DisplayState
 
 	// DB Info
 	ds.CurrentNodeHeight = s.GetHighestSavedBlk()
-	lheight := s.GetLeaderHeight()
-	if s.GetHighestAck() > lheight {
-		lheight = s.GetHighestAck()
-	}
-	tl := s.GetTrueLeaderHeight()
-	if tl > lheight {
-		lheight = tl
-	}
-	ds.CurrentLeaderHeight = lheight
+	lheight := s.GetTrueLeaderHeight()
+	// Acks are from the current block being built, and at +1
+	ds.CurrentLeaderHeight = s.GetLeaderHeight()
 	ds.CurrentEBDBHeight = s.EntryDBHeightComplete
 	ds.LeaderHeight = lheight
 

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -1078,11 +1078,6 @@ func HandleV2Heights(state interfaces.IState, params interface{}) (interface{}, 
 	h := new(HeightsResponse)
 
 	lheight := int64(state.GetTrueLeaderHeight())
-	// Highest ack is the highest leader height.
-	// It may not be the "True" leader height
-	if int64(state.GetHighestAck()) > lheight {
-		lheight = int64(state.GetHighestAck())
-	}
 	h.DirectoryBlockHeight = int64(state.GetHighestSavedBlk())
 	h.LeaderHeight = lheight
 	h.EntryBlockHeight = int64(state.GetHighestSavedBlk())


### PR DESCRIPTION
Revert leaderheight to saved block height by leader

Behavior was taking the processlist being built. Not the saved height.
This is the reverting the behavior to that prior to the v5.0.0 release