### PR TITLE
Fix LocationFromAddress panic on bad Peer.Address

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -133,6 +133,10 @@ func (p *Peer) LocationFromAddress() (location uint32) {
 		}
 		p.Address = ipAddress[0]
 		ip = net.ParseIP(p.Address)
+		if ip == nil {
+			p.logger.Debugf("net.ParseIP(%v) returned nil", p.Address)
+			return 0
+		}
 	}
 	if len(ip) == 16 { // If we got back an IP6 (16 byte) address, use the last 4 byte
 		ip = ip[12:]


### PR DESCRIPTION
This commit fixes Issue #463. An edge case on Linux concerning how
net.LookupAddress resolves its own hostname results in a panic. Check if
ip is nil once more before indexing into ip inside of
Peer.LocationFromAddress.

https://github.com/FactomProject/factomd/issues/463