### PR TITLE
In Overlay.FetchAllBlockKeysFromBucket(...) there was a case that cou…

### DIFF
--- a/database/databaseOverlay/overlay.go
+++ b/database/databaseOverlay/overlay.go
@@ -11,6 +11,7 @@ package databaseOverlay
 import (
 	"encoding/binary"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/FactomProject/factomd/common/constants"
@@ -271,9 +272,14 @@ func (db *Overlay) FetchAllBlockKeysFromBucket(bucket []byte) ([]interfaces.IHas
 	}
 	answer := make([]interfaces.IHash, len(entries))
 	for i := range entries {
-		answer[i], err = primitives.NewShaHash(entries[i])
+		h, err := primitives.NewShaHash(entries[i])
 		if err != nil {
 			return nil, err
+		}
+		if h != nil { // should always happen
+			answer[i] = h
+		} else {
+			fmt.Fprintf(os.Stderr, "Overlay.FetchAllBlockKeysFromBucket() unexpected nil")
 		}
 	}
 	return answer, nil

--- a/state/ack.go
+++ b/state/ack.go
@@ -290,7 +290,7 @@ func (s *State) getACKStatus(hash interfaces.IHash, useOldMsgs bool) (int, inter
 				if m != nil {
 					return constants.AckStatusACK, hash, m.GetTimestamp(), nil, nil
 				}
-				if pl.DirectoryBlock == nil { // can't use m.getTimestap, m might == nil
+				if pl.DirectoryBlock == nil { // can't use m.getTimestamp, m might == nil
 					return constants.AckStatusACK, hash, nil, nil, nil
 				}
 			}


### PR DESCRIPTION
…ld create a interface nil of type IHash. This is the type of object that bites us in the pokemon bug but this is not the pokemon bug itself, just another case of that object type being created and so I fixed it.