### PR TITLE
update to golang 1.10.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/FactomProject/factomd
     docker:
-      - image: circleci/golang:1.10.2
+      - image: circleci/golang:1.10.3
 
     steps:
       - checkout
@@ -44,7 +44,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/FactomProject/factomd
     docker:
-      - image: circleci/golang:1.10.2
+      - image: circleci/golang:1.10.3
 
     steps:
       - checkout
@@ -89,7 +89,7 @@ jobs:
   coveralls:
     working_directory: /go/src/github.com/FactomProject/factomd
     docker:
-      - image: circleci/golang:1.10.2
+      - image: circleci/golang:1.10.3
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.2
+FROM golang:1.10.3
 
 # Get git
 RUN apt-get update \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM golang:1.10.2-alpine  as builder
+FROM golang:1.10.3-alpine  as builder
 
 # Get git
 RUN apk add --no-cache curl git


### PR DESCRIPTION
circleCI was failing with golang 1.10.2 due to a not-found error.  Try 1.10.3.

fixes this error in circleCI
```
Build-agent version 0.0.6347-92eac3d (2018-06-13T18:13:12+0000)
Starting container circleci/golang:1.10.2
  image cache not found on this host, downloading circleci/golang:1.10.2
Error response from daemon: manifest for circleci/golang:1.10.2 not found
```
https://circleci.com/gh/FactomProject/factomd/4751