### PR TITLE
Add CORS domains option to allow calls to Factomd API from browsers

### DIFF
--- a/common/interfaces/state.go
+++ b/common/interfaces/state.go
@@ -77,6 +77,7 @@ type IState interface {
 	GetRpcAuthHash() []byte
 	GetTlsInfo() (bool, string, string)
 	GetFactomdLocations() string
+	GetCorsDomains() []string
 
 	// Routine for handling the syncroniztion of the leader and follower processes
 	// and how they process messages.

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -279,6 +279,7 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "tls", s.FactomdTLSEnable))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "selfaddr", s.FactomdLocations))
 	os.Stderr.WriteString(fmt.Sprintf("%20s \"%s\"\n", "rpcuser", s.RpcUser))
+	os.Stderr.WriteString(fmt.Sprintf("%20s \"%s\"\n", "corsdomains", s.CorsDomains))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %d\n", "Start 2nd Sync at ht", s.EntryDBHeightComplete))
 
 	os.Stderr.WriteString(fmt.Sprintf("%20s %d\n", "faultTimeout", elections.FaultTimeout))

--- a/state/printState.go
+++ b/state/printState.go
@@ -115,6 +115,7 @@ func PrintState(state *State) {
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "factomdTLSKeyFile", state.factomdTLSKeyFile)
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "factomdTLSCertFile", state.factomdTLSCertFile)
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "FactomdLocations", state.FactomdLocations)
+	str = fmt.Sprintf("%s %35s = %+v\n", str, "CorsDomains", state.CorsDomains)
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "StartDelay", state.StartDelay)
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "StartDelayLimit", state.StartDelayLimit)
 	str = fmt.Sprintf("%s %35s = %+v\n", str, "RunLeader", state.RunLeader)

--- a/state/state.go
+++ b/state/state.go
@@ -194,6 +194,8 @@ type State struct {
 	factomdTLSCertFile string
 	FactomdLocations   string
 
+	CorsDomains []string
+
 	// Server State
 	StartDelay      int64 // Time in Milliseconds since the last DBState was applied
 	StartDelayLimit int64
@@ -513,6 +515,8 @@ func (s *State) Clone(cloneNumber int) interfaces.IState {
 	newState.factomdTLSCertFile = s.factomdTLSCertFile
 	newState.FactomdLocations = s.FactomdLocations
 
+	newState.CorsDomains = s.CorsDomains
+
 	switch newState.DBType {
 	case "LDB":
 		newState.StateSaverStruct.FastBoot = s.StateSaverStruct.FastBoot
@@ -593,6 +597,10 @@ func (s *State) SetNetStateOff(net bool) {
 
 func (s *State) GetRpcUser() string {
 	return s.RpcUser
+}
+
+func (s *State) GetCorsDomains() []string {
+	return s.CorsDomains
 }
 
 func (s *State) GetRpcPass() string {
@@ -720,6 +728,14 @@ func (s *State) LoadConfig(filename string, networkFlag string) {
 		s.StateSaverStruct.FastBootLocation = cfg.App.FastBootLocation
 		s.FastBoot = cfg.App.FastBoot
 		s.FastBootLocation = cfg.App.FastBootLocation
+
+		if len(cfg.App.CorsDomains) > 0 {
+			domains := strings.Split(cfg.App.CorsDomains, ",")
+			s.CorsDomains = make([]string, len(domains))
+			for _, domain := range domains {
+				s.CorsDomains = append(s.CorsDomains, strings.Trim(domain, " "))
+			}
+		}
 
 		s.FactomdTLSEnable = cfg.App.FactomdTlsEnabled
 		if cfg.App.FactomdTlsPrivateKey == "/full/path/to/factomdAPIpriv.key" {

--- a/util/config.go
+++ b/util/config.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/log"
-
-	"gopkg.in/gcfg.v1"
 )
 
 var _ = fmt.Print
@@ -63,6 +61,7 @@ type FactomdConfig struct {
 		FactomdTlsPublicCert    string
 		FactomdRpcUser          string
 		FactomdRpcPass          string
+		CorsDomains             string
 
 		ChangeAcksHeight uint32
 	}

--- a/wsapi/wsapi.go
+++ b/wsapi/wsapi.go
@@ -55,6 +55,7 @@ func Start(state interfaces.IState) {
 		server = web.NewServer()
 
 		server.Logger.SetOutput(ioutil.Discard)
+		server.Config.CorsDomains = state.GetCorsDomains()
 
 		Servers[state.GetPort()] = server
 		server.Env["state"] = state


### PR DESCRIPTION
Dependency on https://github.com/FactomProject/web/pull/2
Pass along CORS domains parameters to allow calls to API from browsers.
That's pretty much my first Goland code ever so I'm open to any suggestion.