### PR TITLE
fix issue /w memory on fast boot

### DIFF
--- a/state/processList.go
+++ b/state/processList.go
@@ -1166,9 +1166,15 @@ func NewProcessList(state interfaces.IState, previous *ProcessList, dbheight uin
 		pl.AdminBlock = adminBlock.NewAdminBlock(previous.AdminBlock)
 		pl.EntryCreditBlock, err = entryCreditBlock.NextECBlock(previous.EntryCreditBlock)
 	} else {
-		pl.DirectoryBlock = directoryBlock.NewDirectoryBlock(nil)
-		pl.AdminBlock = adminBlock.NewAdminBlock(nil)
-		pl.EntryCreditBlock, err = entryCreditBlock.NextECBlock(nil)
+		if pl.DBHeight > 0 {
+			pl.DirectoryBlock, _ = state.GetDB().FetchDBlockByHeight(pl.DBHeight)
+			pl.AdminBlock, _ = state.GetDB().FetchABlockByHeight(pl.DBHeight)
+			pl.EntryCreditBlock, _ = state.GetDB().FetchECBlockByHeight(pl.DBHeight)
+		} else {
+			pl.DirectoryBlock = directoryBlock.NewDirectoryBlock(nil)
+			pl.AdminBlock = adminBlock.NewAdminBlock(nil)
+			pl.EntryCreditBlock, err = entryCreditBlock.NextECBlock(nil)
+		}
 	}
 
 	pl.ResetDiffSigTally()

--- a/state/saveAndRestore.go
+++ b/state/saveAndRestore.go
@@ -574,6 +574,9 @@ func (ss *SaveState) RestoreFactomdState(s *State) { //, d *DBState) {
 	}
 	// Set this, as we know it to be true
 	s.DBHeightAtBoot = ss.DBHeight
+
+	// set DBHeightBase to avoid recursively loading process lists
+	s.ProcessLists.DBHeightBase = ss.DBHeight
 	pl := s.ProcessLists.Get(ss.DBHeight)
 
 	// s.AddStatus(fmt.Sprintln("Index: ", index, "dbht:", ss.DBHeight, "lleaderheight", s.LLeaderHeight))


### PR DESCRIPTION
Setting DBHeight Base fixed the memory spike issue.

Found that when we no longer load a process list for all blocks, this caused the db height in the Header to be incorrect so added code to correct this when it happens.

TODO: still need to work on adding a unit test for this