### PR TITLE
Fix to let DB height complete be set differently for each sim

### DIFF
--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -291,15 +291,14 @@ func (s *State) GoSyncEntries() {
 				}
 			}
 
-			if s.EntryDBHeightComplete%1000 == 0 {
-				if firstMissing < 0 {
-					//Only save EntryDBHeightComplete IF it's a multiple of 1000 AND there are no missing entries
-					err := s.DB.SaveDatabaseEntryHeight(s.EntryDBHeightComplete)
-					if err != nil {
-						fmt.Printf("ERROR: %v\n", err)
-					}
+			if firstMissing < 0 {
+				//Only save EntryDBHeightComplete IF it's a multiple of 1000 AND there are no missing entries
+				err := s.DB.SaveDatabaseEntryHeight(s.EntryDBHeightComplete)
+				if err != nil {
+					fmt.Printf("ERROR: %v\n", err)
 				}
 			}
+
 		}
 		lastfirstmissing = firstMissing
 		if firstMissing < 0 {

--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -7,6 +7,7 @@ package state
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/FactomProject/factomd/common/constants"
@@ -168,6 +169,15 @@ func (s *State) MakeMissingEntryRequests() {
 }
 
 func (s *State) GoSyncEntries() {
+
+	height, err := s.DB.FetchDatabaseEntryHeight()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%10s Skipped setting EntryDBHeightComplete - ERROR: %v\n", s.FactomNodeName, err))
+	} else {
+		os.Stderr.WriteString(fmt.Sprintf("%10s set EntryDBHeightComplete: %8d\n", s.FactomNodeName, height))
+		s.EntryDBHeightComplete = height
+	}
+
 	go s.MakeMissingEntryRequests()
 
 	// Map to track what I know is missing
@@ -292,7 +302,6 @@ func (s *State) GoSyncEntries() {
 			}
 
 			if firstMissing < 0 {
-				//Only save EntryDBHeightComplete IF it's a multiple of 1000 AND there are no missing entries
 				err := s.DB.SaveDatabaseEntryHeight(s.EntryDBHeightComplete)
 				if err != nil {
 					fmt.Printf("ERROR: %v\n", err)

--- a/state/state.go
+++ b/state/state.go
@@ -534,14 +534,6 @@ func (s *State) Clone(cloneNumber int) interfaces.IState {
 		os.MkdirAll(path, 0777)
 	}
 
-	height, err := s.DB.FetchDatabaseEntryHeight()
-	if err != nil {
-		os.Stderr.WriteString(fmt.Sprintf("%10s ERROR: %v\n", s.FactomNodeName, err))
-	} else {
-		os.Stderr.WriteString(fmt.Sprintf("%10s loaded to %8d\n", s.FactomNodeName, height))
-		s.EntryDBHeightComplete = height
-	}
-
 	return newState
 }
 
@@ -840,7 +832,7 @@ func (s *State) Init() {
 		s.Salt = primitives.Sha(b)
 	}
 
-	salt := fmt.Sprintf("The Instance ID of this node is %s\n", s.Salt.String()[:16])
+	salt := fmt.Sprintf("The Instance ID of %v node is %s\n", s.FactomNodeName, s.Salt.String()[:16])
 	fmt.Print(salt)
 
 	s.StartDelay = s.GetTimestamp().GetTimeMilli() // We can't start as a leader until we know we are upto date

--- a/state/state.go
+++ b/state/state.go
@@ -533,6 +533,15 @@ func (s *State) Clone(cloneNumber int) interfaces.IState {
 		path := filepath.Join(newState.LdbPath, newState.Network, "dbstates")
 		os.MkdirAll(path, 0777)
 	}
+
+	height, err := s.DB.FetchDatabaseEntryHeight()
+	if err != nil {
+		os.Stderr.WriteString(fmt.Sprintf("%10s ERROR: %v\n", s.FactomNodeName, err))
+	} else {
+		os.Stderr.WriteString(fmt.Sprintf("%10s loaded to %8d\n", s.FactomNodeName, height))
+		s.EntryDBHeightComplete = height
+	}
+
 	return newState
 }
 


### PR DESCRIPTION
This fix should let each sim boot back up w/ the correct complete DB height

Here's an example from manual testing where FNode02 is coming back online at a height lower than the other sims
```
Starting factomd
...
Looking for Config File /home/ork/Workspace/FD-581/.factom/m2/simConfig/factomd001.conf
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.000812 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
INFO[0000] Checking Chainheads starting at height: 4     tool=chainheadtool
INFO[0000] 9 Chains found in 0.000539 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.000352 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.000421 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
    FNode0 set EntryDBHeightComplete:        5
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.001250 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
   FNode01 set EntryDBHeightComplete:        5
INFO[0000] Checking Chainheads starting at height: 4     tool=chainheadtool
INFO[0000] 9 Chains found in 0.000687 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
   FNode02 set EntryDBHeightComplete:        3
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.001309 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
   FNode03 set EntryDBHeightComplete:        5
INFO[0000] Checking Chainheads starting at height: 6     tool=chainheadtool
INFO[0000] 9 Chains found in 0.001328 seconds            tool=chainheadtool
INFO[0000] Chainhead Check Complete. 0 Errors corrected while checking for bad heads  tool=chainheadtool
   FNode04 set EntryDBHeightComplete:        5
```