### PR TITLE
added memleak fix by not cloning Replay during save

### DIFF
--- a/state/replay.go
+++ b/state/replay.go
@@ -96,6 +96,11 @@ func (a *Replay) IsSameAs(b *Replay) bool {
 }
 
 func (r *Replay) MarshalBinary() (rval []byte, err error) {
+	// REVIEW: added locking since Marshal is being executed
+	// against State.Replay rather than a copy from Replay.Save()
+	r.Mutex.Lock()
+	defer r.Mutex.Unlock()
+
 	defer func(pe *error) {
 		if *pe != nil {
 			fmt.Fprintf(os.Stderr, "Replay.MarshalBinary err:%v", *pe)
@@ -153,6 +158,9 @@ func (r *Replay) UnmarshalBinary(p []byte) error {
 }
 
 func (r *Replay) Save() *Replay {
+	// KLUDGE don't make a copy to prevent memory leak
+	return r
+
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
 	newr := new(Replay)

--- a/state/saveAndRestore.go
+++ b/state/saveAndRestore.go
@@ -591,6 +591,7 @@ func (ss *SaveState) RestoreFactomdState(s *State) { //, d *DBState) {
 	s.DBStates.DBStates = s.DBStates.DBStates[:dindex]
 	//s.AddStatus(fmt.Sprintf("SAVESTATE Restoring the State to dbht: %d", ss.DBHeight))
 
+	// REVIEW: should we rebuild Replay from DB instead ?
 	s.Replay = ss.Replay.Save()
 	s.Replay.s = s
 	s.Replay.name = "Replay"


### PR DESCRIPTION
This change may have some unintended consequences in regard to what information is persisted from Replay - need to talk about that w/ @factom-clay 

NOTE: I wonder if could rebuild Replay data from DB rather than persisting to the state snapshot