### PR TITLE
Fd 706 move perm blance to save2

### DIFF
--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -1019,16 +1019,6 @@ func (list *DBStateList) ProcessBlocks(d *DBState) (progress bool) {
 	}
 	list.State.ECBalancesPMutex.Unlock()
 
-	// Process the Factoid End of Block
-	err = fs.AddTransactionBlock(d.FactoidBlock)
-	if err != nil {
-		panic(err)
-	}
-	err = fs.AddECBlock(d.EntryCreditBlock)
-	if err != nil {
-		panic(err)
-	}
-
 	if list.State.DBFinished {
 		list.State.Balancehash = fs.GetBalanceHash(false)
 	}
@@ -1314,6 +1304,8 @@ func (list *DBStateList) SaveDBStateToDB(d *DBState) (progress bool) {
 		}
 	}
 
+	fs := list.State.FactoidState
+
 	if d.Saved {
 		Havedblk, err := list.State.DB.DoesKeyExist(databaseOverlay.DIRECTORYBLOCK, d.DirectoryBlock.GetKeyMR().Bytes())
 		if err != nil || !Havedblk {
@@ -1331,6 +1323,16 @@ func (list *DBStateList) SaveDBStateToDB(d *DBState) (progress bool) {
 				fct.GetSigHash().Fixed(),
 				fct.GetTimestamp(),
 				d.DirectoryBlock.GetHeader().GetTimestamp())
+		}
+
+		// Process the Factoid End of Block
+		err = fs.AddTransactionBlock(d.FactoidBlock)
+		if err != nil {
+			panic(err)
+		}
+		err = fs.AddECBlock(d.EntryCreditBlock)
+		if err != nil {
+			panic(err)
 		}
 
 		return
@@ -1497,6 +1499,16 @@ func (list *DBStateList) SaveDBStateToDB(d *DBState) (progress bool) {
 		if !good {
 			return
 		}
+	}
+
+	// Process the Factoid End of Block
+	err := fs.AddTransactionBlock(d.FactoidBlock)
+	if err != nil {
+		panic(err)
+	}
+	err = fs.AddECBlock(d.EntryCreditBlock)
+	if err != nil {
+		panic(err)
 	}
 
 	// Set the Block Replay flag for all these transactions we are saving to the database.

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/FactomProject/factomd/log"
 )
 
+// Keep these packages
 var _ = hex.EncodeToString
 var _ = fmt.Print
 var _ = time.Now()

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -2450,10 +2450,16 @@ func (s *State) GetF(rt bool, adr [32]byte) (v int64) {
 	ok := false
 	if rt {
 		pl := s.ProcessLists.Get(s.LLeaderHeight)
+		pl2 := s.ProcessLists.Get(s.LLeaderHeight - 1)
 		if pl != nil {
 			pl.FactoidBalancesTMutex.Lock()
 			v, ok = pl.FactoidBalancesT[adr]
 			pl.FactoidBalancesTMutex.Unlock()
+			if !ok && pl2 != nil {
+				pl2.FactoidBalancesTMutex.Lock()
+				v, ok = pl2.FactoidBalancesT[adr]
+				pl2.FactoidBalancesTMutex.Unlock()
+			}
 		} else {
 			s.LogPrintf("factoids", "GetF(%v,%x<%s>) = %d -- no pl", rt, adr[:4],
 				primitives.ConvertFctAddressToUserStr(factoid.NewAddress(adr[:])), v)
@@ -2504,10 +2510,16 @@ func (s *State) GetE(rt bool, adr [32]byte) (v int64) {
 	ok := false
 	if rt {
 		pl := s.ProcessLists.Get(s.LLeaderHeight)
+		pl2 := s.ProcessLists.Get(s.LLeaderHeight - 1)
 		if pl != nil {
 			pl.ECBalancesTMutex.Lock()
 			v, ok = pl.ECBalancesT[adr]
 			pl.ECBalancesTMutex.Unlock()
+			if !ok && pl2 != nil {
+				pl2.ECBalancesTMutex.Lock()
+				v, ok = pl2.ECBalancesT[adr]
+				pl2.ECBalancesTMutex.Unlock()
+			}
 		} else {
 			s.LogPrintf("entrycredits", "GetE(%v,%x<%s>) = %d -- no pl", rt, adr[:4],
 				primitives.ConvertECAddressToUserStr(factoid.NewAddress(adr[:])), v)


### PR DESCRIPTION
Don't update the perm balances until we actually save to disk, to avoid issues where we update our current state with a db-state message after we have processed the data collected in a block.