### PR TITLE
Fix Issue #624

### DIFF
--- a/common/entryBlock/entry.go
+++ b/common/entryBlock/entry.go
@@ -252,8 +252,7 @@ func UnmarshalEntry(data []byte) (interfaces.IEBEntry, error) {
 	return entry, nil
 }
 
-func (e *Entry) UnmarshalBinaryData(data []byte) ([]byte, error) {
-	var err error
+func (e *Entry) UnmarshalBinaryData(data []byte) (_ []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("Error unmarshalling: %v", r)


### PR DESCRIPTION
Add named return values to the function so that the deferred function can properly modify the returned error. 

Naming the return values made it clear that the returned byte slice from this unmarshaler is never not nil. This should be refactored to only return the error.