### PR TITLE
Ignore timestamps on DBSig messages, because they set the timestamp. …

### DIFF
--- a/engine/debug/follow.sh
+++ b/engine/debug/follow.sh
@@ -44,7 +44,7 @@ EOF
 
 (grep -HEm 1 "Send.*$pattern" fnode*_networkoutputs.txt  
 grep -HEm 1 "enqueue.*$pattern" fnode*_networkinputs.txt 
-ls fnode*_executeMsg.txt | xargs -n1 --delimiter "\n" -I%  sh -c "grep -HEm 1 \"Execute.*$pattern\" % | tail -1"
-grep -HEm 1 "Add.*$pattern" fnode*_processList.txt 
+ls fnode*_executemsg.txt | xargs -n1 --delimiter "\n" -I%  sh -c "grep -HEm 1 \"Execute.*$pattern\" % | tail -1"
+grep -HEm 1 "Add.*$pattern" fnode*_processlist.txt 
 grep -HEm 1 "done.*$pattern" fnode*_process.txt) |  awk "$scriptVariable" | sort -n | awk "$scriptVariable2" | grep -E "$pattern" --color='always' | less -R
 

--- a/state/processList.go
+++ b/state/processList.go
@@ -927,9 +927,9 @@ func (p *ProcessList) AddToProcessList(s *State, ack *messages.Ack, m interfaces
 
 	// Make sure we don't put in an old ack (outside our repeat range)
 	blktime := s.GetLeaderTimestamp().GetTime().UnixNano()
-	tlim := int64(Range * 60 * 1000000000)
+	tlim := int64(Range * 60 * 1000 * 1000 * 1000)
 
-	if blktime != 0 {
+	if blktime != 0 && m.Type() != constants.DIRECTORY_BLOCK_SIGNATURE_MSG {
 		acktime := ack.GetTimestamp().GetTime().UnixNano()
 		msgtime := m.GetTimestamp().GetTime().UnixNano()
 		Delta := blktime - acktime

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -244,7 +244,7 @@ func (s *State) Process() (progress bool) {
 	LeaderPL := s.ProcessLists.Get(s.LLeaderHeight)
 
 	if s.LeaderPL != LeaderPL {
-		s.LogPrintf("ExecuteMsg", "Unexpected change in LeaderPL")
+		s.LogPrintf("ExecuteMsg", "Process: Unexpected change in LeaderPL")
 		s.LeaderPL = LeaderPL
 	}
 
@@ -564,7 +564,7 @@ func (s *State) ReviewHolding() {
 			if !x {
 				TotalHoldingQueueOutputs.Inc()
 				//delete(s.Holding, k) // Drop commits with the same entry hash from holding because they are blocked by a previous entry
-				s.DeleteFromHolding(k, v, "already commited")
+				s.DeleteFromHolding(k, v, "already committed")
 				continue
 			}
 		}
@@ -743,7 +743,7 @@ func (s *State) AddDBState(isNew bool,
 		LeaderPL := s.ProcessLists.Get(s.LLeaderHeight)
 
 		if s.LLeaderHeight != 0 && s.LeaderPL != LeaderPL {
-			s.LogPrintf("ExecuteMsg", "Unexpected change in LeaderPL")
+			s.LogPrintf("ExecuteMsg", "AddDBState: Unexpected change in LeaderPL")
 			s.LeaderPL = LeaderPL
 		}
 
@@ -957,7 +957,7 @@ func (s *State) FollowerExecuteDBState(msg interfaces.IMsg) {
 		// Do nothing because this dbstate looks to be invalid
 		cntFail()
 		if dbstatemsg.IsLast { // this is the last DBState in this load
-			s.DBFinished = true // Just in case we toss the last one for some reason
+			panic("The last DBState saved to the database was not valid.")
 		}
 		return
 	}
@@ -1880,7 +1880,7 @@ func (s *State) ProcessEOM(dbheight uint32, msg interfaces.IMsg) bool {
 				}
 				LeaderPL := s.ProcessLists.Get(s.LLeaderHeight)
 				if s.LeaderPL != LeaderPL {
-					s.LogPrintf("ExecuteMsg", "Unexpected change in LeaderPL")
+					s.LogPrintf("ExecuteMsg", "ProcessEOM: Unexpected change in LeaderPL")
 					s.LeaderPL = LeaderPL
 				}
 


### PR DESCRIPTION
… Also added a panic, fixed a spelling error, improved log files, and fixed a debugging script