### PR TITLE
FD-845 Audit/Follower Brainswap - Compare height of heartbeat against state

### DIFF
--- a/common/messages/heartbeat.go
+++ b/common/messages/heartbeat.go
@@ -326,7 +326,9 @@ func (m *Heartbeat) FollowerExecute(is interfaces.IState) {
 		if auditServer.GetChainID().IsSameAs(m.IdentityChainID) {
 			if m.IdentityChainID.IsSameAs(is.GetIdentityChainID()) {
 				if m.SecretNumber != is.GetSalt(m.Timestamp) {
-					panic("We have seen a heartbeat using our Identity that isn't ours")
+					if is.GetDBHeightComplete() >= m.DBHeight {
+						panic("We have seen a heartbeat using our Identity that isn't ours")
+					}
 				}
 			}
 			auditServer.SetOnline(true)


### PR DESCRIPTION
The context of `m` and `is` is a bit low for a beginner, but I believe this does a proper comparison to avoid a panic when an heartbeat is ahead of the node's DBHeight. If this is not on target, let me know the context of `m` and `is` so I can dive back in.