### PR TITLE
improving handling of malformed messages

### DIFF
--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -115,10 +115,6 @@ func (m *Ack) Validate(s interfaces.IState) int {
 		return -1
 	}
 
-	if s.GetHighestAck() < m.DBHeight {
-		s.SetHighestAck(m.DBHeight) // assume the ack isn't lying. this will make us start requesting DBState blocks...
-	}
-
 	delta := (int(m.DBHeight)-int(s.GetLeaderPL().GetDBHeight()))*10 + (int(m.Minute) - int(s.GetCurrentMinute()))
 
 	if delta > 50 {
@@ -126,6 +122,10 @@ func (m *Ack) Validate(s interfaces.IState) int {
 		// when we get caught up we will either get a DBState with this message or we will missing message it.
 		// but if it was malicious then we don't want to keep it around filling up queues.
 		return -1
+	}
+
+	if s.GetHighestAck() < m.DBHeight {
+		s.SetHighestAck(m.DBHeight) // assume the ack isn't lying. this will make us start requesting DBState blocks...
 	}
 
 	if delta > 30 {

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -117,15 +117,21 @@ func (m *Ack) Validate(s interfaces.IState) int {
 
 	delta := (int(m.DBHeight)-int(s.GetLeaderPL().GetDBHeight()))*10 + (int(m.Minute) - int(s.GetCurrentMinute()))
 
+	// Update the highest known ack to start requesting
+	// DBState blocks if necessary
+	if s.GetHighestAck() < m.DBHeight {
+		if delta > 200 { // cap at a relative 200 due to fd-850
+			s.SetHighestAck(s.GetLeaderPL().GetDBHeight() + 200)
+		} else {
+			s.SetHighestAck(m.DBHeight)
+		}
+	}
+
 	if delta > 50 {
 		s.LogMessage("ackQueue", "drop ack from future", m)
 		// when we get caught up we will either get a DBState with this message or we will missing message it.
 		// but if it was malicious then we don't want to keep it around filling up queues.
 		return -1
-	}
-
-	if s.GetHighestAck() < m.DBHeight {
-		s.SetHighestAck(m.DBHeight) // assume the ack isn't lying. this will make us start requesting DBState blocks...
 	}
 
 	if delta > 30 {

--- a/state/authority.go
+++ b/state/authority.go
@@ -110,6 +110,10 @@ func (st *State) VerifyAuthoritySignature(msg []byte, sig *[constants.SIGNATURE_
 //			0  -> Audit Signature
 //			-1 -> Neither Fed or Audit Signature
 func (st *State) FastVerifyAuthoritySignature(msg []byte, sig interfaces.IFullSignature, dbheight uint32) (int, error) {
+	if sig == nil { // no signature = not valid
+		return -1, fmt.Errorf("Message contained no signature")
+	}
+
 	feds := st.GetFedServers(dbheight)
 	if feds == nil {
 		return 0, fmt.Errorf("Federated Servers are unknown at directory block height %d", dbheight)


### PR DESCRIPTION
I believe this prevents the problems described in FD-850, which turned out to be two-fold.

1) The acceptance of Acks's DBHeight has been moved underneath the check that filters out Acks in the distant future. The highest distance now accepted is capped at LeaderHeight + 5.  

2) The signature validation adds a sanity check to filter out messages that do not have a signature at all