### PR TITLE
Fd 858 close tcp connection

### DIFF
--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -58,7 +58,7 @@ func init() {
 	flag.IntVar(&p.TimeOffset, "timedelta", 0, "Maximum timeDelta in milliseconds to offset each node.  Simulates deltas in system clocks over a network.")
 	flag.BoolVar(&p.KeepMismatch, "keepmismatch", false, "If true, do not discard DBStates even when a majority of DBSignatures have a different hash")
 	flag.Int64Var(&p.StartDelay, "startdelay", 10, "Delay to start processing messages, in seconds")
-	flag.IntVar(&p.Deadline, "deadline", 1000, "Timeout Delay in milliseconds used on Reads and Writes to the network comm")
+	flag.IntVar(&p.Deadline, "deadline", 60000, "Timeout Delay in milliseconds used on Reads and Writes to the network comm")
 	flag.StringVar(&p.RpcUser, "rpcuser", "", "Username to protect factomd local API with simple HTTP authentication")
 	flag.StringVar(&p.RpcPassword, "rpcpass", "", "Password to protect factomd local API. Ignored if rpcuser is blank")
 	flag.BoolVar(&p.FactomdTLS, "tls", false, "Set to true to require encrypted connections to factomd API and Control Panel") //to get tls, run as "factomd -tls=true"

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -58,7 +58,7 @@ func init() {
 	flag.IntVar(&p.TimeOffset, "timedelta", 0, "Maximum timeDelta in milliseconds to offset each node.  Simulates deltas in system clocks over a network.")
 	flag.BoolVar(&p.KeepMismatch, "keepmismatch", false, "If true, do not discard DBStates even when a majority of DBSignatures have a different hash")
 	flag.Int64Var(&p.StartDelay, "startdelay", 10, "Delay to start processing messages, in seconds")
-	flag.IntVar(&p.Deadline, "deadline", 60000, "Timeout Delay in milliseconds used on Reads and Writes to the network comm")
+	flag.IntVar(&p.Deadline, "deadline", 300000, "Timeout Delay in milliseconds used on Reads and Writes to the network comm")
 	flag.StringVar(&p.RpcUser, "rpcuser", "", "Username to protect factomd local API with simple HTTP authentication")
 	flag.StringVar(&p.RpcPassword, "rpcpass", "", "Password to protect factomd local API. Ignored if rpcuser is blank")
 	flag.BoolVar(&p.FactomdTLS, "tls", false, "Set to true to require encrypted connections to factomd API and Control Panel") //to get tls, run as "factomd -tls=true"

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -519,7 +519,6 @@ func (c *Connection) handleNetErrors(toss bool) {
 	for {
 		select {
 		case err := <-c.Errors:
-			fmt.Println("DEBUG: NET ERROR", err)
 			// Only go offline once per handleNetErrors call
 			if !toss && !done {
 				if err != nil {

--- a/p2p/connection.go
+++ b/p2p/connection.go
@@ -506,6 +506,7 @@ func (c *Connection) processReceives() {
 				c.TimeLastpacket = time.Now()
 			default: // error
 				c.Errors <- result
+				time.Sleep(100 * time.Millisecond) // give some time to handle states
 			}
 		}
 		// If not online, give some time up to handle states that are not online, closed, or shuttingdown.

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -55,7 +55,7 @@ var (
 	MinumumSharingQualityScore   int32  = 20          // if a peer's score is less than this we don't share them.
 	OnlySpecialPeers                    = false       // dial out to special peers only
 	AllowUnknownIncomingPeers           = true        // allow incoming connections from peers that are not in the special peer list
-	NetworkDeadline                     = time.Duration(30) * time.Second
+	NetworkDeadline                     = time.Duration(60) * time.Second
 	NumberPeersToConnect                = 32
 	NumberPeersToBroadcast              = 8 // This gets overwritten by command line flag!
 	MaxNumberIncomingConnections        = 150

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -55,7 +55,7 @@ var (
 	MinumumSharingQualityScore   int32  = 20          // if a peer's score is less than this we don't share them.
 	OnlySpecialPeers                    = false       // dial out to special peers only
 	AllowUnknownIncomingPeers           = true        // allow incoming connections from peers that are not in the special peer list
-	NetworkDeadline                     = time.Duration(60) * time.Second
+	NetworkDeadline                     = time.Second * 300
 	NumberPeersToConnect                = 32
 	NumberPeersToBroadcast              = 8 // This gets overwritten by command line flag!
 	MaxNumberIncomingConnections        = 150


### PR DESCRIPTION
# Original description of the problem
> There is a bug in the p2p code that handles disconnectiong peers poorly.  If I understand correctly the problem, the tcp connection gets dropped by the other node, but the p2p code doesn't recognize it.  we need to have a way to close a connection when the tcp connection drops.

The current way it works:

Command line argument "deadline" is [defaulted at 1000ms](https://github.com/FactomProject/factomd/blob/d2e5799ab97ce87030bd15ae210080a2e54ae5eb/engine/factomParams.go#L61) and the text is incorrect (see next points).
There's a [write deadline](https://github.com/FactomProject/factomd/blob/d2e5799ab97ce87030bd15ae210080a2e54ae5eb/p2p/connection.go#L468) timed at 500 * command line param (8 minutes, 20 seconds).
All [EOFs are ignored](https://github.com/FactomProject/factomd/blob/d2e5799ab97ce87030bd15ae210080a2e54ae5eb/p2p/connection.go#L509-L514).
All [timeouts are ignored](https://github.com/FactomProject/factomd/blob/d2e5799ab97ce87030bd15ae210080a2e54ae5eb/p2p/connection.go#L538-L539).
There is no read deadline.

Under these circumstances, it's possible that the TCP connection on the remote end disconnects abruptly but the node remains unaware. In golang, a connection throws EOF when the connection is closed, and timeouts when a deadline is exceeded. I'm not sure what the inspiration was for ignoring both of them but I assume that's the source of the problem.

# My proposal:

Default value changed to 60 seconds (60000 ms)
Set both read and write deadlines individually
Shut down the connection if these deadlines are exceeded or the connection closed (basically any error that is thrown)
If the rest of the code works, this will get the node to attempt to reconnect to the peer / wait for the remote peer to connect to the node after a connection failure
Also addresses the potential issue of someone sending very large (>ram size) parcels to overload/crash a server

### Why 60 seconds

This is an arbitrary value that might have to be raised if there are nodes in the network that transmit factom parcels taking longer than a minute. The node logic dictates that for every peer after 15 seconds without any activity, it will send a Ping event and receive a Pong for keepalive. Barring any bandwidth limitations, the deadline could be lowered to 15+tolerance seconds but I see no reason for such a stringent requirement.

It can also be increased to something like it was before (5+ minutes) if you want it to act more or less just as garbage collection.

P.S. I've been running a follower node on testnet for a couple of hours and haven't had any tcp disconnects. Pulling ethernet plug will terminate all active connections and reconnect after ethernet is reestablished.