### PR TITLE
FD-886 Prevent syncmsgs arriving from the network

### DIFF
--- a/common/messages/electionMsgs/syncMsg.go
+++ b/common/messages/electionMsgs/syncMsg.go
@@ -153,6 +153,9 @@ func (m *SyncMsg) Type() byte {
 }
 
 func (m *SyncMsg) Validate(state interfaces.IState) int {
+	if !m.IsLocal() { // FD-886, only accept local messages
+		return -1
+	}
 	//TODO: Must be validated
 	return 1
 }


### PR DESCRIPTION
Small fix to drop any outside SyncMsgs, they are internal messages only.

(TimeoutInternal can't be unmarshaled and is already protected from being accepted via network)