### PR TITLE
Election Sync Cleanup

### DIFF
--- a/common/messages/electionMsgs/syncMsg.go
+++ b/common/messages/electionMsgs/syncMsg.go
@@ -14,7 +14,6 @@ import (
 	"github.com/FactomProject/factomd/common/messages/msgbase"
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/state"
-	"github.com/FactomProject/goleveldb/leveldb/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -229,53 +228,12 @@ func (e *SyncMsg) JSONString() (string, error) {
 }
 
 func (m *SyncMsg) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("Error unmarshalling: %v", r)
-		}
-	}()
-
-	buf := primitives.NewBuffer(data)
-
-	if t, e := buf.PopByte(); e != nil || t != constants.SYNC_MSG {
-		return nil, errors.New("Not a Sync Message Audit type")
-	}
-	if m.TS, err = buf.PopTimestamp(); err != nil {
-		return nil, err
-	}
-	if m.SigType, err = buf.PopBool(); err != nil {
-		return nil, err
-	}
-	if m.Name, err = buf.PopString(); err != nil {
-		return nil, err
-	}
-	if m.ServerIdx, err = buf.PopUInt32(); err != nil {
-		return nil, err
-	}
-	if m.ServerID, err = buf.PopIHash(); err != nil {
-		return nil, err
-	}
-	if m.Weight, err = buf.PopIHash(); err != nil {
-		return nil, err
-	}
-	if m.DBHeight, err = buf.PopUInt32(); err != nil {
-		return nil, err
-	}
-	if m.VMIndex, err = buf.PopInt(); err != nil {
-		return nil, err
-	}
-	if m.Round, err = buf.PopInt(); err != nil {
-		return nil, err
-	}
-	if m.Minute, err = buf.PopByte(); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), err
+	err = fmt.Errorf("SyncMsg is an internal message only")
+	return
 }
 
 func (m *SyncMsg) UnmarshalBinary(data []byte) error {
-	_, err := m.UnmarshalBinaryData(data)
-	return err
+	return fmt.Errorf("SyncMsg is an internal message only")
 }
 
 func (m *SyncMsg) MarshalBinary() (data []byte, err error) {

--- a/common/messages/electionMsgs/syncMsg_test.go
+++ b/common/messages/electionMsgs/syncMsg_test.go
@@ -7,9 +7,6 @@ package electionMsgs_test
 import (
 	"testing"
 
-	"fmt"
-
-	"github.com/FactomProject/factomd/common/constants"
 	. "github.com/FactomProject/factomd/common/messages/electionMsgs"
 	"github.com/FactomProject/factomd/common/messages/msgsupport"
 	"github.com/FactomProject/factomd/common/primitives"
@@ -45,23 +42,9 @@ func TestMarshalUnmarshalSyncMsg(t *testing.T) {
 			t.Error(err)
 		}
 
-		va2, err := msgsupport.UnmarshalMessage(hex)
-		if err != nil {
+		_, err = msgsupport.UnmarshalMessage(hex)
+		if err == nil {
 			t.Error(err)
-		}
-		_, err = va2.JSONString()
-		if err != nil {
-			t.Error(err)
-		}
-
-		if va2.Type() != constants.SYNC_MSG {
-			t.Error(num + " Invalid message type unmarshalled")
-		}
-
-		if sm.IsSameAs(va2) == false {
-			t.Error(num + " Acks are not the same")
-			fmt.Println(sm.String())
-			fmt.Println(va2.String())
 		}
 	}
 	sm := new(SyncMsg)

--- a/common/messages/electionMsgs/timeoutInternal.go
+++ b/common/messages/electionMsgs/timeoutInternal.go
@@ -316,17 +316,12 @@ func (e *TimeoutInternal) JSONString() (string, error) {
 }
 
 func (m *TimeoutInternal) UnmarshalBinaryData(data []byte) (newData []byte, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("Error unmarshalling: %v", r)
-		}
-	}()
+	err = fmt.Errorf("TimeoutInternal is an internal message only")
 	return
 }
 
 func (m *TimeoutInternal) UnmarshalBinary(data []byte) error {
-	_, err := m.UnmarshalBinaryData(data)
-	return err
+	return fmt.Errorf("TimeoutInternal is an internal message only")
 }
 
 func (m *TimeoutInternal) String() string {


### PR DESCRIPTION
Continuation of https://github.com/FactomProject/factomd/pull/669 

I only removed Unmarshalling support in SyncMsg because MarshalBinary is still used in GetMsgHash(), which in turn is used by LogMessage/MessageTrace. This doesn't pose a security risk on its own because messages can't arrive via network anymore and if the code were to be removed, an attacking node could always re-implemented Marshalling on their end anyway. 

TimeoutInternal already behaved this way, I just cleaned up some of the formatting.