### PR TITLE
FD-925_use_different_web_service_muxes

### DIFF
--- a/controlPanel/controlPanel.go
+++ b/controlPanel/controlPanel.go
@@ -145,11 +145,12 @@ func ServeControlPanel(displayStateChannel chan state.DisplayState, statePointer
 	go doEvery(10*time.Second, getRecentTransactions)
 	go manageConnections(connections)
 
-	http.HandleFunc("/", static(indexHandler))
-	http.HandleFunc("/search", searchHandler)
-	http.HandleFunc("/post", postHandler)
-	http.HandleFunc("/factomd", factomdHandler)
-	http.HandleFunc("/factomdBatch", factomdBatchHandler)
+	controlPanelMux := http.NewServeMux()
+	controlPanelMux.HandleFunc("/", static(indexHandler))
+	controlPanelMux.HandleFunc("/search", searchHandler)
+	controlPanelMux.HandleFunc("/post", postHandler)
+	controlPanelMux.HandleFunc("/factomd", factomdHandler)
+	controlPanelMux.HandleFunc("/factomdBatch", factomdBatchHandler)
 
 	tlsIsEnabled, tlsPrivate, tlsPublic := StatePointer.GetTlsInfo()
 	if tlsIsEnabled {
@@ -165,10 +166,10 @@ func ServeControlPanel(displayStateChannel chan state.DisplayState, statePointer
 			time.Sleep(100 * time.Millisecond)
 		}
 		fmt.Println("Starting encrypted Control Panel on https://localhost" + portStr + "/  Please note the HTTPS in the browser.")
-		http.ListenAndServeTLS(portStr, tlsPublic, tlsPrivate, nil)
+		http.ListenAndServeTLS(portStr, tlsPublic, tlsPrivate, controlPanelMux)
 	} else {
 		fmt.Println("Starting Control Panel on http://localhost" + portStr + "/")
-		http.ListenAndServe(portStr, nil)
+		http.ListenAndServe(portStr, controlPanelMux)
 	}
 }
 

--- a/engine/profiler.go
+++ b/engine/profiler.go
@@ -37,6 +37,7 @@ func StartProfiler(mpr int, expose bool) {
 }
 
 func launchPrometheus(port int) {
-	http.Handle("/metrics", prometheus.Handler())
-	go http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", prometheus.Handler())
+	go http.ListenAndServe(fmt.Sprintf(":%d", port), mux)
 }

--- a/engine/profiler.go
+++ b/engine/profiler.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	_ "net/http/pprof"
+	"net/http/pprof"
 	"runtime"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,7 +24,15 @@ func StartProfiler(mpr int, expose bool) {
 	if expose {
 		pre = ""
 	}
-	log.Println(http.ListenAndServe(fmt.Sprintf("%s:%s", pre, logPort), nil))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	log.Println(http.ListenAndServe(fmt.Sprintf("%s:%s", pre, logPort), mux))
 	//runtime.SetBlockProfileRate(100000)
 }
 


### PR DESCRIPTION
 Continuing from: https://github.com/FactomProject/factomd/issues/675

I have also added the separate mux for prometheus. The API already has a separate one, since it's using the [factomproject/web](https://github.com/FactomProject/web) server. 

HTTPs still works for both the control panel and the api, and pprof/prometheus are not accessible via port 8090 anymore, likewise for pprof and prometheus being able to access each other or the control panel. The API has always been separate and was not susceptible to this in the first place.