### PR TITLE
Configurable p2p incoming and outgoing flags

### DIFF
--- a/common/globals/globals.go
+++ b/common/globals/globals.go
@@ -35,6 +35,8 @@ type FactomParams struct {
 	RuntimeLog               bool
 	Exclusive                bool
 	ExclusiveIn              bool
+	P2PIncoming              int
+	P2POutgoing              int
 	Prefix                   string
 	Rotate                   bool
 	TimeOffset               int

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -182,6 +182,13 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 	s.CheckChainHeads.CheckChainHeads = p.CheckChainHeads
 	s.CheckChainHeads.Fix = p.FixChainHeads
 
+	if p.P2PIncoming > 0 {
+		p2p.MaxNumberIncomingConnections = p.P2PIncoming
+	}
+	if p.P2POutgoing > 0 {
+		p2p.NumberPeersToConnect = p.P2POutgoing
+	}
+
 	fmt.Println(">>>>>>>>>>>>>>>>")
 	fmt.Println(">>>>>>>>>>>>>>>> Net Sim Start!")
 	fmt.Println(">>>>>>>>>>>>>>>>")
@@ -270,6 +277,8 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "balancehash", messages.AckBalanceHash))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %s\n", "FNode 0 Salt", s.Salt.String()[:16]))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "enablenet", p.EnableNet))
+	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "net incoming", p2p.MaxNumberIncomingConnections))
+	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "net outgoing", p2p.NumberPeersToConnect))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %v\n", "waitentries", p.WaitEntries))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %d\n", "node", p.ListenTo))
 	os.Stderr.WriteString(fmt.Sprintf("%20s %s\n", "prefix", p.Prefix))

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -30,6 +30,8 @@ func init() {
 	flag.IntVar(&p.FaultTimeout, "faulttimeout", 120, "Seconds before considering Federated servers at-fault. Default is 120.")
 	flag.IntVar(&p.RoundTimeout, "roundtimeout", 30, "Seconds before audit servers will increment rounds and volunteer.")
 	flag.IntVar(&p2p.NumberPeersToBroadcast, "broadcastnum", 16, "Number of peers to broadcast to in the peer to peer networking")
+	flag.IntVar(&p.P2PIncoming, "p2pIncoming", 0, "Override the maximum number of other peers dialing into this node that will be accepted; default 200")
+	flag.IntVar(&p.P2POutgoing, "p2pOutgoing", 0, "Override the maximum number of peers this node will attempt to dial into; default 32")
 	flag.StringVar(&p.ConfigPath, "config", "", "Override the config file location (factomd.conf)")
 	flag.BoolVar(&p.CheckChainHeads, "checkheads", true, "Enables checking chain heads on boot")
 	flag.BoolVar(&p.FixChainHeads, "fixheads", true, "If --checkheads is enabled, then this will also correct any errors reported")

--- a/factomd.conf
+++ b/factomd.conf
@@ -32,7 +32,10 @@
 ;CustomNetworkPort     = 8110
 ;CustomSeedURL         = ""
 ;CustomSpecialPeers    = ""
-
+; The maximum number of other peers dialing into this node that will be accepted
+;P2PIncoming	= 200
+; The maximum number of peers this node will attempt to dial into
+;P2POutgoing	= 32
 ; --------------- NodeMode: FULL | SERVER ----------------
 ;NodeMode                                = FULL
 ;LocalServerPrivKey                      = 4c38c72fc5cdad68f13b74674d3ffb1f3d63a112710868c9b08946553448d26d

--- a/p2p/protocol.go
+++ b/p2p/protocol.go
@@ -56,10 +56,10 @@ var (
 	OnlySpecialPeers                    = false       // dial out to special peers only
 	AllowUnknownIncomingPeers           = true        // allow incoming connections from peers that are not in the special peer list
 	NetworkDeadline                     = time.Duration(30) * time.Second
-	NumberPeersToConnect                = 32
-	NumberPeersToBroadcast              = 8 // This gets overwritten by command line flag!
-	MaxNumberIncomingConnections        = 150
-	MaxNumberOfRedialAttempts           = 5 // How many missing pings (and other) before we give up and close.
+	NumberPeersToConnect                = 32  // default value; changeable in cfg and cmd line
+	NumberPeersToBroadcast              = 8   // This gets overwritten by command line flag!
+	MaxNumberIncomingConnections        = 200 // default value; changeable in cfg and cmd line
+	MaxNumberOfRedialAttempts           = 5   // How many missing pings (and other) before we give up and close.
 	StandardChannelSize                 = 5000
 	NetworkStatusInterval               = time.Second * 9
 	ConnectionStatusInterval            = time.Second * 122

--- a/state/state.go
+++ b/state/state.go
@@ -825,6 +825,13 @@ func (s *State) LoadConfig(filename string, networkFlag string) {
 			s.IdentityChainID = identity
 			s.LogPrintf("AckChange", "Load IdentityChainID \"%v\"", s.IdentityChainID.String())
 		}
+
+		if cfg.App.P2PIncoming > 0 {
+			p2p.MaxNumberIncomingConnections = cfg.App.P2PIncoming
+		}
+		if cfg.App.P2POutgoing > 0 {
+			p2p.NumberPeersToConnect = cfg.App.P2POutgoing
+		}
 	} else {
 		s.LogPath = "database/"
 		s.LdbPath = "database/ldb"

--- a/util/config.go
+++ b/util/config.go
@@ -58,6 +58,8 @@ type FactomdConfig struct {
 		CustomSpecialPeers      string
 		CustomBootstrapIdentity string
 		CustomBootstrapKey      string
+		P2PIncoming             int
+		P2POutgoing             int
 		FactomdTlsEnabled       bool
 		FactomdTlsPrivateKey    string
 		FactomdTlsPublicCert    string
@@ -140,6 +142,10 @@ CustomSeedURL        = ""
 CustomSpecialPeers   = ""
 CustomBootstrapIdentity     = 38bab1455b7bd7e5efd15c53c777c79d0c988e9210f1da49a99d95b3a6417be9
 CustomBootstrapKey          = cc1985cdfae4e32b5a454dfda8ce5e1361558482684f3367649c3ad852c8e31a
+; The maximum number of other peers dialing into this node that will be accepted
+P2PIncoming	= 200
+; The maximum number of peers this node will attempt to dial into
+P2POutgoing	= 32
 ; --------------- NodeMode: FULL | SERVER ----------------
 NodeMode                                = FULL
 LocalServerPrivKey                      = 4c38c72fc5cdad68f13b74674d3ffb1f3d63a112710868c9b08946553448d26d
@@ -240,6 +246,8 @@ func (s *FactomdConfig) String() string {
 	out.WriteString(fmt.Sprintf("\n    CustomSpecialPeers      %v", s.App.CustomSpecialPeers))
 	out.WriteString(fmt.Sprintf("\n    CustomBootstrapIdentity %v", s.App.CustomBootstrapIdentity))
 	out.WriteString(fmt.Sprintf("\n    CustomBootstrapKey      %v", s.App.CustomBootstrapKey))
+	out.WriteString(fmt.Sprintf("\n    P2PIncoming             %v", s.App.P2PIncoming))
+	out.WriteString(fmt.Sprintf("\n    P2POutgoing             %v", s.App.P2POutgoing))
 	out.WriteString(fmt.Sprintf("\n    NodeMode                %v", s.App.NodeMode))
 	out.WriteString(fmt.Sprintf("\n    IdentityChainID         %v", s.App.IdentityChainID))
 	out.WriteString(fmt.Sprintf("\n    LocalServerPrivKey      %v", s.App.LocalServerPrivKey))

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -88,6 +88,10 @@ CustomSeedURL           = ""
 CustomSpecialPeers      = ""
 CustomBootstrapIdentity = 38bab1455b7bd7e5efd15c53c777c79d0c988e9210f1da49a99d95b3a6417be9
 CustomBootstrapKey      = cc1985cdfae4e32b5a454dfda8ce5e1361558482684f3367649c3ad852c8e31a
+; The maximum number of other peers dialing into this node that will be accepted
+P2PIncoming	= 200
+; The maximum number of peers this node will attempt to dial into
+P2POutgoing	= 32
 ; --------------- NodeMode: FULL | SERVER | LIGHT ----------------
 NodeMode                              = FULL
 LocalServerPrivKey                    = 4c38c72fc5cdad68f13b74674d3ffb1f3d63a112710868c9b08946553448d26d


### PR DESCRIPTION
This change raises the cap of max incoming connections to accommodate intermediate network growth, as well as providing config and command line parameters to change these numbers for future adjustments or customization for seed nodes.

Changes:
* Global variable `p2p.MaxNumberIncomingConnections` raised from 150 to 200
* Configuration file variables: `App.P2POutgoing` and `App.P2PIncoming`
* Command line flags: `-p2pOutgoing` and `-p2pIncoming`

Order of evaluation is (from lowest to highest): p2p package default variables, config file, command line