### PR TITLE
Expose the insertEntry call on the database, and use it.  Rework how …

### DIFF
--- a/common/interfaces/databaseOverlay.go
+++ b/common/interfaces/databaseOverlay.go
@@ -33,6 +33,7 @@ type DBOverlaySimple interface {
 	FetchPaidFor(hash IHash) (IHash, error)
 	FetchAllEBlocksByChain(IHash) ([]IEntryBlock, error)
 	InsertEntryMultiBatch(entry IEBEntry) error
+	InsertEntry(entry IEBEntry) error
 	ProcessABlockMultiBatch(block DatabaseBatchable) error
 	ProcessDBlockMultiBatch(block DatabaseBlockWithEntries) error
 	ProcessEBlockBatch(eblock DatabaseBlockWithEntries, checkForDuplicateEntries bool) error

--- a/engine/SimPeer.go
+++ b/engine/SimPeer.go
@@ -7,10 +7,10 @@ package engine
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"time"
 
-	"github.com/FactomProject/factomd/common/constants"
+	"math/rand"
+
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/messages/msgsupport"
 )
@@ -115,56 +115,53 @@ func (f *SimPeer) computeBandwidth() {
 }
 
 func (f *SimPeer) Send(msg interfaces.IMsg) error {
-	data, err := msg.MarshalBinary()
-	f.bytesOut += len(data)
-	f.computeBandwidth()
-	if err != nil {
-		fmt.Println("ERROR on Send: ", err)
-		return err
-	}
-	if len(f.BroadcastOut) < 9000 {
+	go func() {
+
+		if f.Delay > 0 {
+			// Sleep some random number of milliseconds, then send the packet
+			time.Sleep(time.Duration(rand.Intn(int(f.Delay))) * time.Millisecond)
+		}
+
+		data, err := msg.MarshalBinary()
+		f.bytesOut += len(data)
+		f.computeBandwidth()
+		if err != nil {
+			return
+		}
+
 		packet := SimPacket{data: data, sent: time.Now().UnixNano() / 1000000}
 		f.BroadcastOut <- &packet
-	}
+
+	}()
 	return nil
 }
 
 // Non-blocking return value from channel.
 func (f *SimPeer) Receive() (interfaces.IMsg, error) {
-	if f.Delayed == nil {
-		select {
-		case packet, ok := <-f.BroadcastIn:
-			if ok {
-				f.Delayed = packet
-			}
-		default:
-			return nil, nil // Nothing to do
-		}
-		if f.Delay > 0 {
-			f.DelayUse = rand.Int63n(f.Delay)
-		} else {
-			f.DelayUse = 0
-		}
 
+	// We want a packet from the network
+	var packet *SimPacket
+
+	// However, we do not want to wait if one isn't there.
+	select {
+	case packet = <-f.BroadcastIn:
+	default:
+		return nil, nil // Nothing to do
 	}
 
-	now := time.Now().UnixNano() / 1000000
+	// Count the overhead of packets
+	f.bytesIn += len(packet.data)
+	f.computeBandwidth()
 
-	if f.Delayed != nil && now-f.Delayed.sent > f.DelayUse {
-		data := f.Delayed.data
-		f.Delayed = nil
-		msg, err := msgsupport.UnmarshalMessage(data)
-		if err != nil {
-			fmt.Printf("SimPeer ERROR: %s %x %s\n", err.Error(), data[:8], constants.MessageName(data[0]))
-		}
-
-		f.bytesIn += len(data)
-		f.computeBandwidth()
-		return msg, err
-	} else {
-		// fmt.Println("dddd Delay: ", now-f.Delayed.sent)
+	// Unmarshal our message, and throw it a way if we have an error.
+	msg, err := msgsupport.UnmarshalMessage(packet.data)
+	if err != nil {
+		return nil, err
 	}
-	return nil, nil
+
+	// All is good.  Return our message.
+	return msg, err
+
 }
 
 func AddSimPeer(fnodes []*FactomNode, i1 int, i2 int) {

--- a/engine/SimPeer.go
+++ b/engine/SimPeer.go
@@ -115,24 +115,23 @@ func (f *SimPeer) computeBandwidth() {
 }
 
 func (f *SimPeer) Send(msg interfaces.IMsg) error {
-	go func() {
 
+	data, err := msg.MarshalBinary()
+	f.bytesOut += len(data)
+	f.computeBandwidth()
+	if err != nil {
+		return err
+	}
+
+	go func() {
 		if f.Delay > 0 {
 			// Sleep some random number of milliseconds, then send the packet
 			time.Sleep(time.Duration(rand.Intn(int(f.Delay))) * time.Millisecond)
 		}
-
-		data, err := msg.MarshalBinary()
-		f.bytesOut += len(data)
-		f.computeBandwidth()
-		if err != nil {
-			return
-		}
-
 		packet := SimPacket{data: data, sent: time.Now().UnixNano() / 1000000}
 		f.BroadcastOut <- &packet
-
 	}()
+
 	return nil
 }
 

--- a/engine/loadcreate.go
+++ b/engine/loadcreate.go
@@ -8,9 +8,6 @@ import (
 
 	"crypto/sha256"
 
-	"fmt"
-	"os"
-
 	"github.com/FactomProject/factomd/common/entryBlock"
 	"github.com/FactomProject/factomd/common/entryCreditBlock"
 	"github.com/FactomProject/factomd/common/factoid"
@@ -31,6 +28,7 @@ type LoadGenerator struct {
 	running   atomic.AtomicBool      // We are running
 	tight     atomic.AtomicBool      // Only allocate ECs as needed (more EC purchases)
 	txoffset  int64                  // Offset to be added to the timestamp of created tx to test time limits.
+	state     *state.State           // Access to logging
 }
 
 // NewLoadGenerator makes a new load generator. The state is used for funding the transaction
@@ -38,6 +36,7 @@ func NewLoadGenerator(s *state.State) *LoadGenerator {
 	lg := new(LoadGenerator)
 	lg.ECKey, _ = primitives.NewPrivateKeyFromHex(ecSec)
 	lg.stop = make(chan bool, 5)
+	lg.state = s
 
 	return lg
 }
@@ -46,6 +45,7 @@ func (lg *LoadGenerator) Run() {
 	if lg.running.Load() {
 		return
 	}
+
 	lg.running.Store(true)
 	//FundWallet(fnodes[wsapiNode].State, 15000e8)
 
@@ -126,40 +126,43 @@ func (lg *LoadGenerator) NewRevealEntry(entry *entryBlock.Entry) *messages.Revea
 var cnt int
 var goingUp bool
 
-func (lg *LoadGenerator) GetECs(tight bool, c int) {
-	s := fnodes[wsapiNode].State
-	outEC, _ := primitives.HexToHash("c23ae8eec2beb181a0da926bd2344e988149fbe839fbc7489f2096e7d6110243")
-	outAdd := factoid.NewAddress(outEC.Bytes())
-	ecBal := s.GetE(true, outAdd.Fixed())
-	ecPrice := s.GetFactoshisPerEC()
+func (lg *LoadGenerator) KeepUsFunded() {
+	time.Sleep(10 * time.Second)
 
-	if c == 0 || !tight {
-		c += 1000
-	} else {
-		c += 10
-	}
+	var level int64
 
-	cnt++
-	if goingUp && ecBal > 500 {
-		if cnt%1000 == 0 {
-			os.Stderr.WriteString(fmt.Sprintf("%d purchases, not buying %d cause the balance is %d \n", cnt, c, ecBal))
+	buys := 0
+	totalBought := 0
+	for i := 0; ; i++ {
+
+		if lg.tight.Load() {
+			level = 10
+		} else {
+			level = 5000
 		}
-		goingUp = false
-		return
-	}
 
-	if !goingUp && ecBal > int64(c) {
-		if cnt%1000 == 0 {
-			os.Stderr.WriteString(fmt.Sprintf("%d purchases, not buying %d cause the balance is %d \n", cnt, c, ecBal))
+		s := fnodes[wsapiNode].State
+		outEC, _ := primitives.HexToHash("c23ae8eec2beb181a0da926bd2344e988149fbe839fbc7489f2096e7d6110243")
+		outAdd := factoid.NewAddress(outEC.Bytes())
+		ecBal := s.GetE(true, outAdd.Fixed())
+		ecPrice := s.GetFactoshisPerEC()
+
+		if ecBal < level {
+			buys++
+			need := level - ecBal + level*2
+			totalBought += int(need)
+			FundWalletTOFF(s, lg.txoffset, uint64(need)*ecPrice)
 		}
-		return
+		if i%5 == 0 {
+			ts := "false"
+			if lg.tight.Load() {
+				ts = "true"
+			}
+			lg.state.LogPrintf("loadgenerator", "Tight %7s Total TX %6d for a total of %8d entry credits balance %d.",
+				ts, buys, totalBought, ecBal)
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
-
-	os.Stderr.WriteString(fmt.Sprintf("%d purchases, buying %d and balance is %d \n", cnt, c, ecBal))
-
-	FundWalletTOFF(s, lg.txoffset, uint64(c)*ecPrice)
-	goingUp = true
-
 }
 
 func (lg *LoadGenerator) NewCommitChain(entry *entryBlock.Entry) *messages.CommitChainMsg {
@@ -171,7 +174,6 @@ func (lg *LoadGenerator) NewCommitChain(entry *entryBlock.Entry) *messages.Commi
 	data, _ := entry.MarshalBinary()
 	commit.Credits, _ = util.EntryCost(data)
 	commit.Credits += 10
-	lg.GetECs(lg.tight.Load(), int(commit.Credits))
 
 	commit.EntryHash = entry.GetHash()
 	var b6 primitives.ByteSlice6
@@ -200,7 +202,6 @@ func (lg *LoadGenerator) NewCommitEntry(entry *entryBlock.Entry) *messages.Commi
 	data, _ := entry.MarshalBinary()
 
 	commit.Credits, _ = util.EntryCost(data)
-	lg.GetECs(lg.tight.Load(), int(commit.Credits))
 
 	commit.EntryHash = entry.GetHash()
 	var b6 primitives.ByteSlice6

--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -105,6 +105,7 @@ func SimControl(listenTo int, listenStdin bool) {
 
 	if loadGenerator == nil {
 		loadGenerator = NewLoadGenerator(fnodes[0].State)
+		go loadGenerator.KeepUsFunded()
 	}
 
 	for {
@@ -166,8 +167,6 @@ func SimControl(listenTo int, listenStdin bool) {
 						break
 					}
 					if b[1] == 'f' {
-						loadGenerator.GetECs(true, 1000)
-						//FundWallet(fnodes[wsapiNode].State, uint64(200*5e7))
 						break
 					}
 				}
@@ -178,7 +177,6 @@ func SimControl(listenTo int, listenStdin bool) {
 				wsapi.SetState(fnodes[wsapiNode].State)
 
 				if nextAuthority == -1 {
-					loadGenerator.GetECs(true, 1000)
 					//err, _ := FundWallet(fnodes[wsapiNode].State, 2e7)
 					//if err != nil {
 					//	os.Stderr.WriteString(fmt.Sprintf("Error in funding the wallet, %s\n", err.Error()))
@@ -199,7 +197,6 @@ func SimControl(listenTo int, listenStdin bool) {
 							os.Stderr.WriteString(fmt.Sprint("You can only pop a max of 100 off the stack at a time."))
 							count = 100
 						}
-						loadGenerator.GetECs(true, 1000)
 						//err := fundWallet(fnodes[wsapiNode].State, uint64(count*5e7))
 						//if err != nil {
 						//	os.Stderr.WriteString(fmt.Sprintf("Error in funding the wallet, %s\n", err.Error()))
@@ -963,7 +960,6 @@ func SimControl(listenTo int, listenStdin bool) {
 					}
 					wsapiNode = ListenTo
 					wsapi.SetState(fnodes[wsapiNode].State)
-					loadGenerator.GetECs(true, 1000)
 
 					//err, _ := FundWallet(fnodes[ListenTo].State, 1e8)
 					//if err != nil {
@@ -1188,9 +1184,7 @@ func SimControl(listenTo int, listenStdin bool) {
 				}
 			case 'R' == b[0]:
 				// load generation
-				if loadGenerator == nil && len(fnodes) > ListenTo {
-					loadGenerator = NewLoadGenerator(fnodes[ListenTo].State)
-				} else if loadGenerator == nil {
+				if loadGenerator == nil {
 					os.Stderr.WriteString("Currently no default State we can use for the load generator\n")
 					continue
 				}
@@ -1261,7 +1255,6 @@ func SimControl(listenTo int, listenStdin bool) {
 
 				wsapiNode = ListenTo
 				wsapi.SetState(fnodes[wsapiNode].State)
-				loadGenerator.GetECs(true, 1000)
 				//err = fundWallet(fnodes[ListenTo].State, 1e8)
 				//if err != nil {
 				//	os.Stderr.WriteString(fmt.Sprintf("Error in funding the wallet, %s\n", err.Error()))
@@ -1291,7 +1284,6 @@ func SimControl(listenTo int, listenStdin bool) {
 
 				wsapiNode = ListenTo
 				wsapi.SetState(fnodes[wsapiNode].State)
-				loadGenerator.GetECs(true, 1000)
 				//err = fundWallet(fnodes[ListenTo].State, 1e8)
 				//if err != nil {
 				//	os.Stderr.WriteString(fmt.Sprintf("Error in funding the wallet, %s\n", err.Error()))

--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -1123,7 +1123,7 @@ func SimControl(listenTo int, listenStdin bool) {
 					for _, p := range f.Peers {
 						sim, ok := p.(*SimPeer)
 						if ok {
-							sim.Delay = nnn
+							sim.Delay = nnn // Set the delay in milliseconds
 						}
 					}
 				}

--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -71,7 +71,7 @@ func (s *State) WriteEntries() {
 		entry := <-s.WriteEntry
 		if entry != nil && !has(s, entry.GetHash()) {
 			s.DB.StartMultiBatch()
-			err := s.DB.InsertEntryMultiBatch(entry)
+			err := s.DB.InsertEntry(entry)
 			if err != nil {
 				panic(err)
 			}

--- a/state/entrySyncing.go
+++ b/state/entrySyncing.go
@@ -70,12 +70,10 @@ func (s *State) WriteEntries() {
 	for {
 		entry := <-s.WriteEntry
 		if entry != nil && !has(s, entry.GetHash()) {
-			s.DB.StartMultiBatch()
 			err := s.DB.InsertEntry(entry)
 			if err != nil {
 				panic(err)
 			}
-			err = s.DB.ExecuteMultiBatch()
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
…we save entries in SaveDBState() in the DBStateManager

Fixes a stall because we are not really writing entries to the database, and a possible stall where saving very large blocks to the database lock out the WriteEntries go routine in Entry Syncing