### PR TITLE
Runtimelog doesn't respect its own enabled setting

### DIFF
--- a/engine/MsgLogging.go
+++ b/engine/MsgLogging.go
@@ -53,6 +53,9 @@ func (m *MsgLog) Init(enable bool, nodecnt int) {
 }
 
 func (m *MsgLog) Add2(fnode *FactomNode, out bool, peer string, where string, valid bool, msg interfaces.IMsg) {
+	if !m.Enable {
+		return
+	}
 	m.sem.Lock()
 	defer m.sem.Unlock()
 	now := fnode.State.GetTimestamp()
@@ -98,6 +101,10 @@ func (m *MsgLog) Add2(fnode *FactomNode, out bool, peer string, where string, va
 }
 
 func (m *MsgLog) PrtMsgs(state interfaces.IState) {
+	if !m.Enable {
+		fmt.Println("Message log is not enabled. Run factomd with runtime log enabled.")
+		return
+	}
 	m.sem.Lock()
 	defer m.sem.Unlock()
 


### PR DESCRIPTION
The command line flag -runtimeLog lets you enable/disable the runtimelog, which is the log of messages you can print via the console "m" command. It buffers 4 seconds worth of messages internally, after which the buffer is cleared.

At the moment, the function that buffers message doesn't respect the setting whether or not it's enabled. This fix will:
* Disable message buffering when the runtimeLog flag is turned off, saving a little bit of memory and cpu
* Print out an info message if someone turns on message logging in the console with the setting disabled