### PR TITLE
FD-564 : Corrected compile issues on BalanceFinder.

### DIFF
--- a/Utilities/BalanceFinder/main.go
+++ b/Utilities/BalanceFinder/main.go
@@ -59,6 +59,7 @@ func main() {
 	fmt.Println("Usage:")
 	fmt.Println("BalanceFinder level/bolt/api DBFileLocation")
 	fmt.Println("Program will find balances")
+	fmt.Println("All balance hashes cannot be compared to those presented in factomd. Only compared to others made by the tool.")
 
 	if len(flag.Args()) < 2 {
 		fmt.Println("\nNot enough arguments passed")
@@ -180,8 +181,11 @@ func FindBalance(reader tools.Fetcher) (map[[32]byte]int64, map[[32]byte]int64, 
 		// Print the balance hash
 		if heightmap[i] == true {
 			{
-				h1 := state.GetMapHash(i, fctAddressMap)
-				h2 := state.GetMapHash(i, ecAddressMap)
+				// The dbheight was removed from the call, and the balance hash is
+				// added in another piece of code that we cannot easily access from this tool.
+				// So this tool's hashes can only be compared to other hashes made by this tool.
+				h1 := state.GetMapHash(fctAddressMap)
+				h2 := state.GetMapHash(ecAddressMap)
 
 				var b []byte
 				b = append(b, h1.Bytes()...)

--- a/Utilities/tools/fetcher.go
+++ b/Utilities/tools/fetcher.go
@@ -3,11 +3,12 @@ package tools
 import (
 	"encoding/hex"
 
-	"fmt"
-
 	"github.com/FactomProject/factom"
+	"github.com/FactomProject/factomd/common/adminBlock"
 	"github.com/FactomProject/factomd/common/directoryBlock"
 	"github.com/FactomProject/factomd/common/entryBlock"
+	"github.com/FactomProject/factomd/common/entryCreditBlock"
+	"github.com/FactomProject/factomd/common/factoid"
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/database/databaseOverlay"
@@ -17,15 +18,24 @@ import (
 const level string = "level"
 const bolt string = "bolt"
 
-// Able to be either a datbase or api
 type Fetcher interface {
+	SetChainHeads(primaryIndexes, chainIDs []interfaces.IHash) error
+
 	FetchDBlockHead() (interfaces.IDirectoryBlock, error)
-	FetchDBlockByHeight(dBlockHeight uint32) (interfaces.IDirectoryBlock, error)
 	//FetchDBlock(hash interfaces.IHash) (interfaces.IDirectoryBlock, error)
 	FetchHeadIndexByChainID(chainID interfaces.IHash) (interfaces.IHash, error)
 	FetchEBlock(hash interfaces.IHash) (interfaces.IEntryBlock, error)
-	SetChainHeads(primaryIndexes, chainIDs []interfaces.IHash) error
+
+	FetchEntry(hash interfaces.IHash) (interfaces.IEBEntry, error)
+	FetchDBlockByHeight(dBlockHeight uint32) (interfaces.IDirectoryBlock, error)
+	FetchABlockByHeight(blockHeight uint32) (interfaces.IAdminBlock, error)
+	FetchFBlockByHeight(blockHeight uint32) (interfaces.IFBlock, error)
+	FetchECBlockByHeight(blockHeight uint32) (interfaces.IEntryCreditBlock, error)
+	FetchECBlockByPrimary(keymr interfaces.IHash) (interfaces.IEntryCreditBlock, error)
 }
+
+var _ Fetcher = (*APIReader)(nil)
+var _ Fetcher = (*databaseOverlay.Overlay)(nil)
 
 func NewDBReader(levelBolt string, path string) *databaseOverlay.Overlay {
 	var dbase *hybridDB.HybridDB
@@ -59,13 +69,26 @@ func (a *APIReader) SetChainHeads(primaryIndexes, chainIDs []interfaces.IHash) e
 	return nil
 }
 
+func (a *APIReader) FetchEntry(hash interfaces.IHash) (interfaces.IEBEntry, error) {
+	raw, err := factom.GetRaw(hash.String())
+	if err != nil {
+		return nil, err
+	}
+
+	entry := entryBlock.NewEntry()
+	err = UnmarshalGeneric(entry, raw)
+	return entry, err
+}
+
 func (a *APIReader) FetchEBlock(hash interfaces.IHash) (interfaces.IEntryBlock, error) {
-	return nil, fmt.Errorf("Not implmented for api")
-	//raw, err := factom.GetRaw(hash.String())
-	//if err != nil {
-	//	return nil, err
-	//}
-	//return rawBytesToEblock(raw)
+	raw, err := factom.GetRaw(hash.String())
+	if err != nil {
+		return nil, err
+	}
+
+	block := entryBlock.NewEBlock()
+	err = UnmarshalGeneric(block, raw)
+	return block, err
 }
 
 func (a *APIReader) FetchDBlockHead() (interfaces.IDirectoryBlock, error) {
@@ -77,16 +100,85 @@ func (a *APIReader) FetchDBlockHead() (interfaces.IDirectoryBlock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return rawBytesToDblock(raw)
+
+	block := directoryBlock.NewDirectoryBlock(nil)
+	err = UnmarshalGeneric(block, raw)
+	return block, err
 }
 
-func (a *APIReader) FetchDBlockByHeight(dBlockHeight uint32) (interfaces.IDirectoryBlock, error) {
-	raw, err := factom.GetBlockByHeightRaw("d", int64(dBlockHeight))
+func (a *APIReader) FetchDBlockByHeight(height uint32) (interfaces.IDirectoryBlock, error) {
+	raw, err := factom.GetBlockByHeightRaw("d", int64(height))
 	if err != nil {
 		return nil, err
 	}
 
-	return rawRespToBlock(raw.RawData)
+	data, err := hex.DecodeString(raw.RawData)
+	if err != nil {
+		return nil, err
+	}
+
+	block := directoryBlock.NewDirectoryBlock(nil)
+	err = UnmarshalGeneric(block, data)
+	return block, err
+}
+
+func (a *APIReader) FetchFBlockByHeight(height uint32) (interfaces.IFBlock, error) {
+	raw, err := factom.GetBlockByHeightRaw("f", int64(height))
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := hex.DecodeString(raw.RawData)
+	if err != nil {
+		return nil, err
+	}
+
+	block := factoid.NewFBlock(nil)
+	err = UnmarshalGeneric(block, data)
+	return block, err
+}
+
+func (a *APIReader) FetchABlockByHeight(height uint32) (interfaces.IAdminBlock, error) {
+	raw, err := factom.GetBlockByHeightRaw("a", int64(height))
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := hex.DecodeString(raw.RawData)
+	if err != nil {
+		return nil, err
+	}
+
+	ablock := adminBlock.NewAdminBlock(nil)
+	err = UnmarshalGeneric(ablock, data)
+	return ablock, err
+}
+
+func (a *APIReader) FetchECBlockByPrimary(keymr interfaces.IHash) (interfaces.IEntryCreditBlock, error) {
+	data, err := factom.GetRaw(keymr.String())
+	if err != nil {
+		return nil, err
+	}
+
+	ecblock := entryCreditBlock.NewECBlock()
+	err = UnmarshalGeneric(ecblock, data)
+	return ecblock, err
+}
+
+func (a *APIReader) FetchECBlockByHeight(height uint32) (interfaces.IEntryCreditBlock, error) {
+	raw, err := factom.GetBlockByHeightRaw("ec", int64(height))
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := hex.DecodeString(raw.RawData)
+	if err != nil {
+		return nil, err
+	}
+
+	ecblock := entryCreditBlock.NewECBlock()
+	err = UnmarshalGeneric(ecblock, data)
+	return ecblock, err
 }
 
 func (a *APIReader) FetchHeadIndexByChainID(chainID interfaces.IHash) (interfaces.IHash, error) {
@@ -97,28 +189,10 @@ func (a *APIReader) FetchHeadIndexByChainID(chainID interfaces.IHash) (interface
 	return primitives.HexToHash(resp)
 }
 
-func rawBytesToEblock(raw []byte) (interfaces.IEntryBlock, error) {
-	eblock := entryBlock.NewEBlock()
-	err := eblock.UnmarshalBinary(raw)
+func UnmarshalGeneric(i interfaces.BinaryMarshallable, raw []byte) error {
+	err := i.UnmarshalBinary(raw)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return eblock, nil
-}
-
-func rawBytesToDblock(raw []byte) (interfaces.IDirectoryBlock, error) {
-	dblock := directoryBlock.NewDirectoryBlock(nil)
-	err := dblock.UnmarshalBinary(raw)
-	if err != nil {
-		return nil, err
-	}
-	return dblock, nil
-}
-
-func rawRespToBlock(raw string) (interfaces.IDirectoryBlock, error) {
-	by, err := hex.DecodeString(raw)
-	if err != nil {
-		return nil, err
-	}
-	return rawBytesToDblock(by)
+	return nil
 }


### PR DESCRIPTION
When solving the compile issues, the balance hash calculation was
changed in the code. The tool cannnot create the same balance
hashes as factomd does without more work to emulate the factoid state.

If we use the factoid state in the tool, that would ruin the point of
the tool checking the balances. As this tool calculates the balances
with different logic.