### PR TITLE
Fd 883 failing back to back brainswap longtest

### DIFF
--- a/state/processList.go
+++ b/state/processList.go
@@ -989,7 +989,7 @@ func (p *ProcessList) AddToProcessList(s *State, ack *messages.Ack, m interfaces
 	TotalAcksInputs.Inc()
 
 	// If this is us, make sure we ignore (if old or in the ignore period) or die because two instances are running.
-	//
+	// When the ack is from the future, don't panic, when it's from the past honor older/newer than 120 seconds rule below
 	if !ack.Response && ack.LeaderChainID.IsSameAs(s.IdentityChainID) && ack.DBHeight <= s.LLeaderHeight {
 		now := s.GetTimestamp().GetTimeSeconds()
 		ackSeconds := ack.Timestamp.GetTimeSeconds()

--- a/state/processList.go
+++ b/state/processList.go
@@ -990,7 +990,7 @@ func (p *ProcessList) AddToProcessList(s *State, ack *messages.Ack, m interfaces
 
 	// If this is us, make sure we ignore (if old or in the ignore period) or die because two instances are running.
 	//
-	if !ack.Response && ack.LeaderChainID.IsSameAs(s.IdentityChainID) {
+	if !ack.Response && ack.LeaderChainID.IsSameAs(s.IdentityChainID) && ack.DBHeight <= s.LLeaderHeight {
 		now := s.GetTimestamp().GetTimeSeconds()
 		ackSeconds := ack.Timestamp.GetTimeSeconds()
 		if now-ackSeconds > 120 {

--- a/state/processList_test.go
+++ b/state/processList_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/FactomProject/factomd/common/messages"
 	"github.com/FactomProject/factomd/common/primitives"
 	. "github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
@@ -87,4 +88,30 @@ func TestServerMap(t *testing.T) {
 	if vmIdx != 2 {
 		t.Error("Unexpected VM index in ServerMap")
 	}
+}
+
+/*
+ * A panic shouldn't occurs when a node receives a future ACK messages with the same ID.
+ * This can occurs during a brain swap.
+ */
+func TestBrainSwapAck(t *testing.T) {
+	state := testHelper.CreateAndPopulateTestState()
+
+	// init ack message
+	m := new(messages.Ack)
+	m.SetLeaderChainID(primitives.RandomHash())
+	m.DBHeight = state.GetLLeaderHeight() + 1
+	m.Timestamp = primitives.NewTimestampNow()
+	m.MessageHash = primitives.RandomHash()
+	m.SerialHash = primitives.RandomHash()
+
+	ack := state.NewAck(m, state.Balancehash).(*messages.Ack)
+
+	// Change the timestamp of the ack message so the SaltNumber if different, i.e. the secret number used to detect multiple servers with the same ID
+	ack.Timestamp = primitives.NewTimestampFromSeconds(primitives.NewTimestampNow().GetTimeSecondsUInt32() + 10)
+
+	// change the db height such that the ack of the brain swap will be processed in the wrong process list.
+	ack.DBHeight = state.LLeaderHeight + 1
+
+	state.ProcessLists.Get(ack.DBHeight).AddToProcessList(state, ack, m)
 }


### PR DESCRIPTION
Laurens also added an extra unit test which fails when the fix is removed.