### PR TITLE
FD-809: Inflation limit

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -278,6 +278,12 @@ var (
 	// 		:: Default = 6.4*1e8
 	COINBASE_PAYOUT_AMOUNT = uint64(6.4 * 1e8)
 
+	// Limited number of 100 fed servers in the network at 0% efficiency
+	COINBASE_PAYOUT_SERVER_LIMIT = uint64(100) * COINBASE_PAYOUT_AMOUNT
+
+	// Total grant limit for one block, 9000000000000 is the highest ever recorded
+	COINBASE_PAYOUT_GRANT_LIMIT = uint64(9000000000000)
+
 	// The height at which coinbase transactions will activate.
 	//	 This is useful for updating without needing to take
 	// 	 down the network and giving an update period.

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -844,7 +844,7 @@ func (list *DBStateList) FixupLinks(p *DBState, d *DBState) (progress bool) {
 				continue
 			}
 			amt := primitives.CalculateCoinbasePayout(ia.Efficiency)
-			if amt == 0 {
+			if amt == 0 || amt > constants.COINBASE_PAYOUT_SERVER_LIMIT {
 				continue
 			}
 

--- a/state/factoidstate.go
+++ b/state/factoidstate.go
@@ -436,6 +436,18 @@ func (fs *FactoidState) GetCoinbaseTransaction(dbheight uint32, ftime interfaces
 				m[v] = struct{}{}
 			}
 
+			totalGrantAmount := uint64(0)
+			for i, o := range desc.Outputs {
+				if _, ok := m[uint32(i)]; !ok {
+					totalGrantAmount += o.GetAmount()
+				}
+			}
+
+			// Auto-cancel when the total amount exceeds the grant limit
+			if totalGrantAmount > constants.COINBASE_PAYOUT_GRANT_LIMIT {
+				return coinbase
+			}
+
 			for i, o := range desc.Outputs {
 				// Only elements not in map are ok
 				if _, ok := m[uint32(i)]; !ok {


### PR DESCRIPTION
Initial proposal.
Please check the comments inside the "Files changed" and let me know it it matches what you expected. I've also considered keeping track of the inflation over a longer history of blocks. But this seems like a task for a monitoring /alert tool, however we could auto-cancel all payouts when the inflation rate over the last x number of blocks goes over a certain limit .