### PR TITLE
FD-1084 : A synced node keeps requesting dbstates even after it is synced

### DIFF
--- a/common/constants/ack.go
+++ b/common/constants/ack.go
@@ -4,6 +4,14 @@
 
 package constants
 
+const (
+	// MaxAckHeightMinuteDelta is the maximum number of minute in the
+	//	future we will set our HighestAckHeight too. This means
+	// 	2000/10 = max number of blocks to set the max height too ontop
+	//	of our current block height.
+	MaxAckHeightMinuteDelta = 2000
+)
+
 // Ack status levels
 const (
 	_ int = iota

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -115,13 +115,13 @@ func (m *Ack) Validate(s interfaces.IState) int {
 		return -1
 	}
 
-	delta := (int(m.DBHeight) - int(s.GetLeaderPL().GetDBHeight()))
+	delta := (int(m.DBHeight)-int(s.GetLeaderPL().GetDBHeight()))*10 + (int(m.Minute) - int(s.GetCurrentMinute()))
 
 	// Update the highest known ack to start requesting
 	// DBState blocks if necessary
 	if s.GetHighestAck() < m.DBHeight {
-		if delta > 2000 { // cap at a relative 2000 due to fd-850
-			s.SetHighestAck(s.GetLeaderPL().GetDBHeight() + 2000)
+		if delta > 2000 { // cap at a relative 200 blks due to fd-850
+			s.SetHighestAck(s.GetLeaderPL().GetDBHeight() + 2000/10)
 		} else {
 			s.SetHighestAck(m.DBHeight)
 		}

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -115,7 +115,7 @@ func (m *Ack) Validate(s interfaces.IState) int {
 		return -1
 	}
 
-	delta := (int(m.DBHeight)-int(s.GetLeaderPL().GetDBHeight()))*10 + (int(m.Minute) - int(s.GetCurrentMinute()))
+	delta := (int(m.DBHeight) - int(s.GetLeaderPL().GetDBHeight()))
 
 	// Update the highest known ack to start requesting
 	// DBState blocks if necessary

--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -120,8 +120,8 @@ func (m *Ack) Validate(s interfaces.IState) int {
 	// Update the highest known ack to start requesting
 	// DBState blocks if necessary
 	if s.GetHighestAck() < m.DBHeight {
-		if delta > 2000 { // cap at a relative 200 blks due to fd-850
-			s.SetHighestAck(s.GetLeaderPL().GetDBHeight() + 2000/10)
+		if delta > constants.MaxAckHeightMinuteDelta { // cap at a relative 200 blks due to fd-850
+			s.SetHighestAck(s.GetLeaderPL().GetDBHeight() + constants.MaxAckHeightMinuteDelta/10)
 		} else {
 			s.SetHighestAck(m.DBHeight)
 		}

--- a/state/dbStateCatchup.go
+++ b/state/dbStateCatchup.go
@@ -59,6 +59,7 @@ func (list *DBStateList) Catchup() {
 		// if it is not received and not already requested.
 		notifyMissing := func(n uint32) bool {
 			if !waiting.Has(n) {
+				list.State.LogPrintf("dbstatecatchup", "{actual} notify missing %d", n)
 				missing.Add(n)
 				return true
 			}
@@ -153,7 +154,7 @@ func (list *DBStateList) Catchup() {
 			// TODO:	that might be made
 			max := 3000 // Limit the number of new asks we will add for each iteration
 			// add all known states after the last received to the missing list
-			for n := received.Heighestreceived() + 1; n < hk && max > 0; n++ {
+			for n := received.Heighestreceived() + 1; n <= hk && max > 0; n++ {
 				max--
 				// missing.Notify <- NewMissingState(n)
 				r := notifyMissing(n)
@@ -179,7 +180,7 @@ func (list *DBStateList) Catchup() {
 			//for e := waiting.List.Front(); e != nil; e = e.Next() {
 			for _, s := range waitingSlice {
 				// Instead of choosing if to ask for it, just remove it
-				if s.Height() < base {
+				if s.Height() <= base {
 					waiting.LockAndDelete(s.Height())
 					continue
 				}
@@ -232,7 +233,7 @@ func (list *DBStateList) Catchup() {
 
 				msg := messages.NewDBStateMissing(list.State, b, e)
 				msg.SendOut(list.State, msg)
-				list.State.DBStateAskCnt += int(e-b) + 1 // Total number of dbstates requested
+				list.State.DBStateAskCnt += 1 // Total number of dbstates requests
 				for i := b; i <= e; i++ {
 					list.State.LogPrintf("dbstatecatchup", "\tdbstate requested : missing -> waiting %d", i)
 					missing.LockAndDelete(i)

--- a/state/dbStateCatchup_test.go
+++ b/state/dbStateCatchup_test.go
@@ -339,6 +339,8 @@ func testDBStateListAdditionsMissing(list GenericList, t *testing.T, testname st
 }
 
 func TestMissingConsecutive(t *testing.T) {
+	testMissingConsecutive(t, []int{10, 11, 12, 13, 20}, 10, 10, 13)
+	testMissingConsecutive(t, []int{10, 11, 12, 13}, 10, 10, 13)
 	testMissingConsecutive(t, []int{10, 11, 12, 13, 15, 20}, 10, 10, 13)
 	testMissingConsecutive(t, []int{10, 11, 12, 13, 15, 20}, 2, 10, 12)
 	testMissingConsecutive(t, []int{1, 10, 11, 12, 13, 15, 20}, 10, 1, 1)
@@ -355,7 +357,7 @@ func testMissingConsecutive(t *testing.T, add []int, n, bExp, eExp int) {
 	}
 
 	b, e := m.NextConsecutiveMissing(n)
-	if b != uint32(bExp) && e != uint32(eExp) {
+	if b != uint32(bExp) || e != uint32(eExp) {
 		t.Errorf("Expected %d-%d, found %d-%d", bExp, eExp, b, e)
 	}
 }

--- a/state/dbStateCatchup_test.go
+++ b/state/dbStateCatchup_test.go
@@ -337,3 +337,25 @@ func testDBStateListAdditionsMissing(list GenericList, t *testing.T, testname st
 	//	t.Errorf("Exp len of 0, found %d", list.Len())
 	//}
 }
+
+func TestMissingConsecutive(t *testing.T) {
+	testMissingConsecutive(t, []int{10, 11, 12, 13, 15, 20}, 10, 10, 13)
+	testMissingConsecutive(t, []int{10, 11, 12, 13, 15, 20}, 2, 10, 12)
+	testMissingConsecutive(t, []int{1, 10, 11, 12, 13, 15, 20}, 10, 1, 1)
+	testMissingConsecutive(t, []int{10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21}, 10, 10, 20)
+	testMissingConsecutive(t, []int{}, 10, 0, 0)
+	testMissingConsecutive(t, []int{1, 2}, 10, 1, 2)
+
+}
+
+func testMissingConsecutive(t *testing.T, add []int, n, bExp, eExp int) {
+	m := state.NewStatesMissing()
+	for _, a := range add {
+		m.Add(uint32(a))
+	}
+
+	b, e := m.NextConsecutiveMissing(n)
+	if b != uint32(bExp) && e != uint32(eExp) {
+		t.Errorf("Expected %d-%d, found %d-%d", bExp, eExp, b, e)
+	}
+}


### PR DESCRIPTION
Caused by an off by one when choosing what dbstates to request.