### PR TITLE
FD-795 Optimistic Entry Writing

### DIFF
--- a/simTest/BrainSwap_test.go
+++ b/simTest/BrainSwap_test.go
@@ -14,7 +14,7 @@ follower and a leader + follower and an audit
 at the same height in the same build
 */
 func TestBrainSwap(t *testing.T) {
-	ResetSimHome(t) // clear out old test home
+	ResetSimHome(t)          // clear out old test home
 	for i := 0; i < 6; i++ { // build config files for the test
 		WriteConfigFile(i, i, "", t) // just write the minimal config
 	}

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -1514,11 +1514,7 @@ func (list *DBStateList) SaveDBStateToDB(d *DBState) (progress bool) {
 			if err != nil {
 				panic(err)
 			}
-			if _, ok := allowedEBlocks[keymr.Fixed()]; ok {
-				for _, e := range eb.GetBody().GetEBEntries() {
-					pl.State.WriteEntry <- pl.GetNewEntry(e.Fixed())
-				}
-			} else {
+			if _, ok := allowedEBlocks[keymr.Fixed()]; !ok {
 				list.State.LogPrintf("dbstateprocess", "Error saving eblock from process list, eblock not allowed")
 			}
 		}

--- a/state/state.go
+++ b/state/state.go
@@ -960,17 +960,17 @@ func (s *State) Init() {
 	s.tickerQueue = make(chan int, 100)               //ticks from a clock
 	s.timerMsgQueue = make(chan interfaces.IMsg, 100) //incoming eom notifications, used by leaders
 	s.ControlPanelChannel = make(chan DisplayState, 20)
-	s.networkInvalidMsgQueue = make(chan interfaces.IMsg, 100)               //incoming message queue from the network messages
-	s.networkOutMsgQueue = NewNetOutMsgQueue(constants.INMSGQUEUE_MED)       //Messages to be broadcast to the network
-	s.inMsgQueue = NewInMsgQueue(constants.INMSGQUEUE_HIGH)                  //incoming message queue for Factom application messages
-	s.inMsgQueue2 = NewInMsgQueue(constants.INMSGQUEUE_HIGH)                 //incoming message queue for Factom application messages
-	s.electionsQueue = NewElectionQueue(constants.INMSGQUEUE_HIGH)           //incoming message queue for Factom application messages
-	s.apiQueue = NewAPIQueue(constants.INMSGQUEUE_HIGH)                      //incoming message queue from the API
-	s.ackQueue = make(chan interfaces.IMsg, 50)                              //queue of Leadership messages
-	s.msgQueue = make(chan interfaces.IMsg, 50)                              //queue of Follower messages
-	s.MissingEntries = make(chan *MissingEntry, constants.INMSGQUEUE_HIGH)   //Entries I discover are missing from the database
-	s.UpdateEntryHash = make(chan *EntryUpdate, constants.INMSGQUEUE_HIGH)   //Handles entry hashes and updating Commit maps.
-	s.WriteEntry = make(chan interfaces.IEBEntry, constants.INMSGQUEUE_HIGH) //Entries to be written to the database
+	s.networkInvalidMsgQueue = make(chan interfaces.IMsg, 100)              //incoming message queue from the network messages
+	s.networkOutMsgQueue = NewNetOutMsgQueue(constants.INMSGQUEUE_MED)      //Messages to be broadcast to the network
+	s.inMsgQueue = NewInMsgQueue(constants.INMSGQUEUE_HIGH)                 //incoming message queue for Factom application messages
+	s.inMsgQueue2 = NewInMsgQueue(constants.INMSGQUEUE_HIGH)                //incoming message queue for Factom application messages
+	s.electionsQueue = NewElectionQueue(constants.INMSGQUEUE_HIGH)          //incoming message queue for Factom application messages
+	s.apiQueue = NewAPIQueue(constants.INMSGQUEUE_HIGH)                     //incoming message queue from the API
+	s.ackQueue = make(chan interfaces.IMsg, 50)                             //queue of Leadership messages
+	s.msgQueue = make(chan interfaces.IMsg, 50)                             //queue of Follower messages
+	s.MissingEntries = make(chan *MissingEntry, constants.INMSGQUEUE_HIGH)  //Entries I discover are missing from the database
+	s.UpdateEntryHash = make(chan *EntryUpdate, constants.INMSGQUEUE_HIGH)  //Handles entry hashes and updating Commit maps.
+	s.WriteEntry = make(chan interfaces.IEBEntry, constants.INMSGQUEUE_LOW) //Entries to be written to the database
 
 	if s.Journaling {
 		f, err := os.Create(s.JournalFile)

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -1360,9 +1360,8 @@ func (s *State) FollowerExecuteDataResponse(m interfaces.IMsg) {
 		if !ok {
 			return
 		}
-		if len(s.WriteEntry) < cap(s.WriteEntry) {
-			s.WriteEntry <- entry // DataResponse
-		}
+		go func() { s.WriteEntry <- entry }() // DataResponse
+
 	}
 }
 
@@ -1845,7 +1844,7 @@ func (s *State) ProcessRevealEntry(dbheight uint32, m interfaces.IMsg) (worked b
 		// Put it in our list of new Entry Blocks for this Directory Block
 		s.PutNewEBlocks(dbheight, chainID, eb)
 		s.PutNewEntries(dbheight, myhash, msg.Entry)
-
+		go func() { s.WriteEntry <- msg.Entry }()
 		s.IncEntryChains()
 		s.IncEntries()
 		s.LogMessage("newHolding", "process", m)
@@ -1877,6 +1876,7 @@ func (s *State) ProcessRevealEntry(dbheight uint32, m interfaces.IMsg) (worked b
 	// Put it in our list of new Entry Blocks for this Directory Block
 	s.PutNewEBlocks(dbheight, chainID, eb)
 	s.PutNewEntries(dbheight, myhash, msg.Entry)
+	go func() { s.WriteEntry <- msg.Entry }()
 
 	s.IncEntries()
 	return true

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -1325,7 +1325,7 @@ func (s *State) FollowerExecuteDataResponse(m interfaces.IMsg) {
 		if !ok {
 			return
 		}
-		go func() { s.WriteEntry <- entry }() // DataResponse
+		s.WriteEntry <- entry // DataResponse
 
 	}
 }
@@ -1809,7 +1809,7 @@ func (s *State) ProcessRevealEntry(dbheight uint32, m interfaces.IMsg) (worked b
 		// Put it in our list of new Entry Blocks for this Directory Block
 		s.PutNewEBlocks(dbheight, chainID, eb)
 		s.PutNewEntries(dbheight, myhash, msg.Entry)
-		go func() { s.WriteEntry <- msg.Entry }()
+		s.WriteEntry <- msg.Entry
 		s.IncEntryChains()
 		s.IncEntries()
 		s.LogMessage("newHolding", "process", m)
@@ -1841,7 +1841,7 @@ func (s *State) ProcessRevealEntry(dbheight uint32, m interfaces.IMsg) (worked b
 	// Put it in our list of new Entry Blocks for this Directory Block
 	s.PutNewEBlocks(dbheight, chainID, eb)
 	s.PutNewEntries(dbheight, myhash, msg.Entry)
-	go func() { s.WriteEntry <- msg.Entry }()
+	s.WriteEntry <- msg.Entry
 
 	s.IncEntries()
 	return true
@@ -2043,9 +2043,6 @@ func (s *State) ProcessEOM(dbheight uint32, msg interfaces.IMsg) bool {
 				entries := []interfaces.IEBEntry{}
 				for _, v := range pl.NewEBlocks {
 					eBlocks = append(eBlocks, v)
-				}
-				for _, v := range pl.NewEntries {
-					entries = append(entries, v)
 				}
 
 				dbstate := s.AddDBState(true, s.LeaderPL.DirectoryBlock, s.LeaderPL.AdminBlock, s.GetFactoidState().GetCurrentBlock(), s.LeaderPL.EntryCreditBlock, eBlocks, entries)

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -905,6 +905,18 @@ func HandleV2Entry(state interfaces.IState, params interface{}) (interface{}, *p
 		}
 	}
 
+	// With FD-795, we have optimistic entry writing.
+	// To ensure the entry actually exists, we need to try
+	// fetching the eblock hash. If it exists, then the entry exists
+	// in the blockchain.
+	included, err := state.GetDB().FetchIncludedIn(h)
+	if err != nil {
+		return nil, NewInternalError()
+	}
+	if included == nil {
+		return nil, NewEntryNotFoundError()
+	}
+
 	e.ChainID = entry.GetChainIDHash().String()
 	e.Content = hex.EncodeToString(entry.GetContent())
 	for _, v := range entry.ExternalIDs() {

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -1006,18 +1006,19 @@ func HandleV2Entry(state interfaces.IState, params interface{}) (interface{}, *p
 		if entry == nil {
 			return nil, NewEntryNotFoundError()
 		}
-	}
 
-	// With FD-795, we have optimistic entry writing.
-	// To ensure the entry actually exists, we need to try
-	// fetching the eblock hash. If it exists, then the entry exists
-	// in the blockchain.
-	included, err := state.GetDB().FetchIncludedIn(h)
-	if err != nil {
-		return nil, NewInternalError()
-	}
-	if included == nil {
-		return nil, NewEntryNotFoundError()
+		// When fetching from the database, optimistic entry writing
+		// might have added entries not in the blockchain.
+		// To ensure the entry actually exists, we need to try
+		// fetching the eblock hash. If it exists, then the entry exists
+		// in the blockchain.
+		included, err := state.GetDB().FetchIncludedIn(h)
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		if included == nil {
+			return nil, NewEntryNotFoundError()
+		}
 	}
 
 	e.ChainID = entry.GetChainIDHash().String()


### PR DESCRIPTION
Write entries when they are processed.  In addition, put them into the old maps so that pending entries don't get broken.  But we do remove the block oriented writes of entries between blocks.