### PR TITLE
remove zapier webhook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,8 +395,3 @@ workflows:
           context: org-global
           requires:
             - test_full
-
-notify:
-  webhooks:
-    - url: https://hooks.zapier.com/hooks/catch/2398659/i8hgb6/
-


### PR DESCRIPTION
This isn't needed, I don't think we rely on it for anything 

I've added a slack integration to replace this.