### PR TITLE
Added of date for data commit entry to endpoint "ack"

### DIFF
--- a/wsapi/ack.go
+++ b/wsapi/ack.go
@@ -186,6 +186,16 @@ func handleAckByEntryHash(hash interfaces.IHash, state interfaces.IState) (inter
 			answer.CommitTxID = txid.String()
 			answer.CommitData.Status = constants.AckStatusString(constants.AckStatusDBlockConfirmed)
 		}
+		_, _, txTime, _, err := state.GetSpecificACKStatus(txid)
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		if txTime != nil {
+			answer.CommitData.TransactionDate = txTime.GetTimeMilli()
+			if txTime.GetTimeMilli() > 0 {
+				answer.CommitData.TransactionDateString = txTime.String()
+			}
+		}
 
 		// Now we will exit, as any commit found below will be less than dblock confirmed.
 		return answer, nil


### PR DESCRIPTION
Our core developer added `transactiondate` & `transactiondatestring` into factomd API `ack` response.

So, `ack` of entry now contains the timestamp of entry creation (transaction).
Looks like this timestamp existed in `entry-ack`, but was lost during refactoring from `entry-ack` → `ack`, now we return it back.

I have tested it and it works correctly.