### PR TITLE
bump savestate version so that it gets rebuilt with the balancehash fix

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -474,4 +474,4 @@ const (
 
 //Fast boot save state version (savestate)
 //To be increased whenever the data being saved changes from the last version
-const SaveStateVersion = 11
+const SaveStateVersion = 12


### PR DESCRIPTION
This is the same version that gets generated with Parchment.  The new version of factomd (xuan) will need to have the version set to 13, because the Cotton version does not have the fix for stopping at blocks divisible by 1000 (FD-1091).