### PR TITLE
FD-1169 Allow DBsigs that are created before boot time to be valid

### DIFF
--- a/engine/factomd.go
+++ b/engine/factomd.go
@@ -59,7 +59,12 @@ func Factomd(params *FactomParams, listenToStdin bool) interfaces.IState {
 	state0.FactomNodeName = state0.Prefix + "FNode0"
 	state0.TimestampAtBoot = primitives.NewTimestampNow()
 	state0.SetLeaderTimestamp(state0.TimestampAtBoot)
-	state0.SetMessageFilterTimestamp(state0.TimestampAtBoot)
+
+	// build a timestamp 20 minutes before boot so we will accept messages from nodes who booted before us.
+	preBootTime := new(primitives.Timestamp)
+	preBootTime.SetTimeMilli(state0.TimestampAtBoot.GetTimeMilli() - 20*60*1000)
+	state0.SetMessageFilterTimestamp(preBootTime)
+
 	state0.EFactory = new(electionMsgs.ElectionsFactory)
 
 	NetStart(state0, params, listenToStdin)

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -955,7 +955,6 @@ func (list *DBStateList) ProcessBlocks(d *DBState) (progress bool) {
 	// its links patched, so we can't process it.  But if this is a repeat block (we have already processed
 	// at this height) then we simply return.
 	if d.Locked || d.IsNew || d.Repeat {
-
 		s.LogPrintf("dbstateprocess", "ProcessBlocks(%d) Skipping d.Locked(%v) || d.IsNew(%v) || d.Repeat(%v) : ", dbht, d.Locked, d.IsNew, d.Repeat)
 		return false
 	}
@@ -1212,9 +1211,9 @@ func (list *DBStateList) ProcessBlocks(d *DBState) (progress bool) {
 		// if we are following by blocks then this move us forward but if we are following by minutes the
 		// code in ProcessEOM for minute 10 will have moved us forward
 		s.SetLeaderTimestamp(d.DirectoryBlock.GetTimestamp())
-		s.MoveStateToHeight(dbht+1, 0)
 		// todo: is there a reason not to do this in MoveStateToHeight?
 		fs.(*FactoidState).DBHeight = dbht + 1
+		s.MoveStateToHeight(dbht+1, 0)
 	}
 
 	// Note about dbsigs.... If we processed the previous minute, then we generate the DBSig for the next block.

--- a/state/loadDatabase.go
+++ b/state/loadDatabase.go
@@ -50,6 +50,7 @@ func LoadDatabase(s *State) {
 
 	//msg, err := s.LoadDBState(blkCnt)
 	start := s.GetDBHeightComplete()
+	numberOfBlocksLoaded := 0 // The number of blocks we load off disk
 
 	if start > 0 {
 		start++
@@ -90,6 +91,7 @@ func LoadDatabase(s *State) {
 
 			s.LogMessage("InMsgQueue", "enqueue_LoadDatabase1", msg)
 			msg.SetLocal(true)
+			numberOfBlocksLoaded++
 			s.InMsgQueue().Enqueue(msg)
 			if s.InMsgQueue().Length() > 200 || len(s.DBStatesReceived) > 50 {
 				for s.InMsgQueue().Length() > 50 || len(s.DBStatesReceived) > 50 {
@@ -104,7 +106,7 @@ func LoadDatabase(s *State) {
 		s.Print("\r", "\\|/-"[i%4:i%4+1])
 	}
 
-	if blkCnt == 0 {
+	if numberOfBlocksLoaded == 0 { // No blocks loaded from disk, therefore generate the genesis
 		s.Println("\n***********************************")
 		s.Println("******* New Database **************")
 		s.Println("***********************************\n")

--- a/state/saveAndRestore.go
+++ b/state/saveAndRestore.go
@@ -732,7 +732,7 @@ func (ss *SaveState) MarshalBinary() (rval []byte, err error) {
 	}
 	defer func(pe *error) {
 		if *pe != nil {
-			fmt.Fprintf(os.Stderr, "SaveState.MarshalBinary err:%v", *pe)
+			fmt.Fprintf(os.Stderr, "SaveState.MarshalBinary err:%v\n", *pe)
 		}
 	}(&err)
 	buf := primitives.NewBuffer(nil)

--- a/state/state.go
+++ b/state/state.go
@@ -2236,7 +2236,7 @@ func (s *State) GetMessageFilterTimestamp() interfaces.Timestamp {
 }
 
 // the MessageFilterTimestamp  is used to filter messages from the past or before the replay filter.
-// We will not set it to a time that is before boot or more than one hour in the past.
+// We will not set it to a time that is before (20 minutes before) boot or more than one hour in the past.
 // this ensure messages from prior boot and messages that predate the current replay filter are
 // are dropped.
 // It marks the start of the replay filter content
@@ -2253,8 +2253,12 @@ func (s *State) SetMessageFilterTimestamp(leaderTS interfaces.Timestamp) {
 		requestedTS.SetTimestamp(onehourago)
 	}
 
-	if requestedTS.GetTimeMilli() < s.TimestampAtBoot.GetTimeMilli() {
-		requestedTS.SetTimestamp(s.TimestampAtBoot)
+	// build a timestamp 20 minutes before boot so we will accept messages from nodes who booted before us.
+	preBootTime := new(primitives.Timestamp)
+	preBootTime.SetTimeMilli(s.TimestampAtBoot.GetTimeMilli() - 20*60*1000)
+
+	if requestedTS.GetTimeMilli() < preBootTime.GetTimeMilli() {
+		requestedTS.SetTimestamp(preBootTime)
 	}
 
 	if s.MessageFilterTimestamp != nil && requestedTS.GetTimeMilli() < s.MessageFilterTimestamp.GetTimeMilli() {

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -898,48 +898,6 @@ func (s *State) AddDBState(isNew bool,
 		fmt.Fprintf(os.Stderr, "AddDBState() out of order! at %d added %d\n", s.LLeaderHeight, ht)
 		//panic("AddDBState out of order!")
 	}
-	if ht > s.LLeaderHeight {
-		s.LogPrintf("dbstateprocess", "unexpected: ht > s.LLeaderHeight  at %d added %d", s.LLeaderHeight, ht)
-
-		//fmt.Println(fmt.Sprintf("SigType PROCESS: %10s Add DBState: s.SigType(%v)", s.FactomNodeName, s.SigType))
-		s.MoveStateToHeight(ht, 0) // AddDBState()
-		s.StartDelay = s.GetTimestamp().GetTimeMilli()
-		s.RunLeader = false
-		LeaderPL := s.ProcessLists.Get(s.LLeaderHeight)
-
-		if s.LLeaderHeight != 0 && s.LeaderPL != LeaderPL {
-			s.LogPrintf("ExecuteMsg", "AddDBState: Unexpected change in LeaderPL")
-			s.LeaderPL = LeaderPL
-		}
-		s.SetLeaderTimestamp(dbState.DirectoryBlock.GetTimestamp()) // move the leader timestamp to the start of the block
-		{
-			// Okay, we have just loaded a new DBState.  The temp balances are no longer valid, if they exist.  Nuke them.
-			s.LeaderPL.FactoidBalancesTMutex.Lock()
-			s.LeaderPL.FactoidBalancesT = map[[32]byte]int64{}
-			s.LeaderPL.FactoidBalancesTMutex.Unlock()
-
-			s.LeaderPL.ECBalancesTMutex.Lock()
-			s.LeaderPL.ECBalancesT = map[[32]byte]int64{}
-			s.LeaderPL.ECBalancesTMutex.Unlock()
-		}
-
-		Leader, LeaderVMIndex := s.LeaderPL.GetVirtualServers(s.CurrentMinute, s.IdentityChainID) // AddDBState()
-		{                                                                                         // debug
-			if s.Leader != Leader {
-				s.LogPrintf("executeMsg", "State.AddDBState() unexpectedly setting s.Leader to %v", Leader)
-				s.Leader = Leader
-			}
-			if s.LeaderVMIndex != LeaderVMIndex {
-				s.LogPrintf("executeMsg", "State.AddDBState()  unexpectedly setting s.LeaderVMIndex to %v", LeaderVMIndex)
-				s.LeaderVMIndex = LeaderVMIndex
-			}
-		}
-		for s.ProcessLists.UpdateState(s.LLeaderHeight) {
-		}
-	}
-	if ht == 0 && s.LLeaderHeight == 0 {
-		s.MoveStateToHeight(1, 0)
-	}
 
 	return dbState
 }


### PR DESCRIPTION
This branch also includes fixes from FD-1124, which are already in cotton.