### PR TITLE
FD-1137 allow golang 1.13 to compile factomd

### DIFF
--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -166,6 +166,10 @@ func isCompilerVersionOK() bool {
 	if strings.Contains(runtime.Version(), "1.12") {
 		goodenough = true
 	}
+
+	if strings.Contains(runtime.Version(), "1.13") {
+		goodenough = true
+	}
 	return goodenough
 }
 


### PR DESCRIPTION
Golang 1.13 is still in beta, but factomd has been tested against the beta version of the compiler for a week or so.  No problems have been detected.  Version 1.13 will likely be released in a few weeks and it would be good to be able to run factomd with that version of golang.