### PR TITLE
FD-1171 bump savestate for xuan to 13

### DIFF
--- a/common/constants/constants.go
+++ b/common/constants/constants.go
@@ -483,4 +483,4 @@ const (
 
 //Fast boot save state version (savestate)
 //To be increased whenever the data being saved changes from the last version
-const SaveStateVersion = 12
+const SaveStateVersion = 13


### PR DESCRIPTION
The federated servers are running v6.4.1, which has the bugfix for double counting of transactions in some of the blocks, FD-1124.

6.4.1 does not included the bugfix for FD-1091, which affects nodes that are shut down on blocks divisible by 1000, but that is included in the parchment/xuan code.  In order to fix any problems that may have been introduced by that bug, force a rescan when installing xuan, so that the state is known to not have been built with either of the bugs.