### PR TITLE
FD-1112 Simplify timer.go

### DIFF
--- a/engine/timer.go
+++ b/engine/timer.go
@@ -5,72 +5,32 @@
 package engine
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/FactomProject/factomd/common/interfaces"
-	s "github.com/FactomProject/factomd/state"
+	"github.com/FactomProject/factomd/state"
 )
 
-var _ = (*s.State)(nil)
-
+// Timer
+// Provides a tick add inserts it into the TickerQueue to trigger EOM generation by
+// leaders.
 func Timer(stateI interfaces.IState) {
-	state := stateI.(*s.State)
+	s := stateI.(*state.State)
 	time.Sleep(2 * time.Second)
-
-	tenthPeriod := state.GetMinuteDuration()
-
-	now := time.Now().UnixNano() // Time in billionths of a second
-
-	wait := tenthPeriod.Nanoseconds() - (now % tenthPeriod.Nanoseconds())
-
-	next := now + wait + tenthPeriod.Nanoseconds()
-
-	if state.GetOut() {
-		state.Print(fmt.Sprintf("Time: %v\r\n", time.Now()))
-	}
-
-	time.Sleep(time.Duration(wait))
 
 	for {
 		for i := 0; i < 10; i++ {
-			// Don't stuff messages into the system if the
-			// Leader is behind.
-			for j := 0; j < 10 && len(state.AckQueue()) > 1000; j++ {
-				time.Sleep(time.Millisecond * 10)
-			}
+			tenthPeriod := s.GetMinuteDuration().Nanoseconds()       // The length of the minute can change, so do this each time
+			now := time.Now().UnixNano()                             // Get the current time
+			time.Sleep(time.Duration(tenthPeriod - now%tenthPeriod)) // Sleep the length of time from now to the next minute
 
-			now = time.Now().UnixNano()
-			if now > next {
-				next += tenthPeriod.Nanoseconds()
-				wait = next - now
-			} else {
-				wait = next - now
-				next += tenthPeriod.Nanoseconds()
-			}
-			time.Sleep(time.Duration(wait))
+			// Delay some number of milliseconds.  This is a debugging tool for testing how well we handle
+			// Leaders running with slightly different minutes in test environments.
+			time.Sleep(time.Duration(s.GetTimeOffset().GetTimeMilli()) * time.Millisecond)
 
-			// Delay some number of milliseconds.
-			time.Sleep(time.Duration(state.GetTimeOffset().GetTimeMilli()) * time.Millisecond)
+			s.TickerQueue() <- -1 // -1 indicated this is real minute cadence
 
-			state.TickerQueue() <- -1 // -1 indicated this is real minute cadence
-
-			tenthPeriod = state.GetMinuteDuration()
-			state.LogPrintf("ticker", "Tick! %d, wait=%s, tenthPeriod=%s", i, time.Duration(wait), time.Duration(tenthPeriod))
+			s.LogPrintf("ticker", "Tick! %d, tenthPeriod=%s", i, time.Duration(tenthPeriod))
 		}
 	}
-}
-
-func PrintBusy(state interfaces.IState, i int) {
-	s := state.(*s.State)
-
-	if len(s.ShutdownChan) == 0 {
-		if state.GetOut() {
-			state.Print(fmt.Sprintf("\r%19s: %s %s",
-				"Timer",
-				state.String(),
-				(string)((([]byte)("-\\|/-\\|/-="))[i])))
-		}
-	}
-
 }


### PR DESCRIPTION
Remove old logging, sync to the start of the minute with each pass of the timer, remove complexity (that might be subject to slippage) from the syncing to minute boundaries.