### PR TITLE
FD-1208 20 minute grace for DBsigs + pokemon + timestamps

### DIFF
--- a/common/messages/ack.go
+++ b/common/messages/ack.go
@@ -119,7 +119,8 @@ func (m *Ack) Validate(s interfaces.IState) int {
 		s.SetHighestAck(m.DBHeight)
 	}
 
-	if m.DBHeight-s.GetLLeaderHeight() > 5 {
+	// drop future acks that are far in the future and not near the block we expect to build as soon as the boot finishes.
+	if m.DBHeight-s.GetLLeaderHeight() > 5 && m.DBHeight != s.GetHighestKnownBlock() && m.DBHeight != s.GetHighestKnownBlock()+1 {
 		s.LogMessage("executeMsg", "drop, from far future", m)
 		return -1
 	}

--- a/common/messages/directoryBlockSignature.go
+++ b/common/messages/directoryBlockSignature.go
@@ -482,7 +482,7 @@ func (m *DirectoryBlockSignature) String() string {
 		m.DirectoryBlockHeader.GetPrevKeyMR().Bytes()[:3],
 		headerHash.Bytes()[:3],
 		m.DirectoryBlockHeader.GetBodyMR().Bytes()[:3],
-		m.Timestamp,
+		m.Timestamp.GetTimeMilli(),
 		m.Timestamp.String(),
 		m.GetHash().Bytes()[:3],
 		stringCompress(m.DirectoryBlockHeader.String()))

--- a/common/messages/eom.go
+++ b/common/messages/eom.go
@@ -361,13 +361,15 @@ func (m *EOM) String() string {
 	if m.FactoidVM {
 		f = "F"
 	}
-	return fmt.Sprintf("%6s-%30s FF %2d %1s-Leader[%x] hash[%x] %s",
+	return fmt.Sprintf("%6s-%30s FF %2d %1s-Leader[%x] hash[%x] ts %d %s %s",
 		"EOM",
-		fmt.Sprintf("DBh/VMh/h %d/%d/-- minute %d", m.DBHeight, m.VMIndex, m.Minute),
+		fmt.Sprintf("DBh/VMh/h %d/%02d/-- minute %2d", m.DBHeight, m.VMIndex, m.Minute),
 		m.SysHeight,
 		f,
 		m.ChainID.Bytes()[3:6],
 		m.GetMsgHash().Bytes()[:3],
+		m.Timestamp.GetTimeMilli(),
+		m.Timestamp.String(),
 		local)
 }
 

--- a/common/messages/msgbase/MessageBase.go
+++ b/common/messages/msgbase/MessageBase.go
@@ -144,7 +144,7 @@ func checkForDuplicateSend(s interfaces.IState, msg interfaces.IMsg, whereAmI st
 }
 
 func (m *MessageBase) SendOut(s interfaces.IState, msg interfaces.IMsg) {
-	if msg.GetRepeatHash() == nil { // Do not send pokemon messages
+	if msg.GetRepeatHash() == nil || reflect.ValueOf(msg.GetRepeatHash()).IsNil() || msg.GetMsgHash() == nil || reflect.ValueOf(msg.GetMsgHash()).IsNil() { // Do not send pokemon messages
 		return
 	}
 

--- a/engine/NetworkProcessorNet.go
+++ b/engine/NetworkProcessorNet.go
@@ -213,7 +213,9 @@ func Peers(fnode *FactomNode) {
 				}
 
 				if fnode.State.LLeaderHeight < fnode.State.DBHeightAtBoot+2 {
-					if msg.GetTimestamp().GetTimeMilli() < fnode.State.TimestampAtBoot.GetTimeMilli() {
+					s := fnode.State
+                                        // Allow 20 minute grace period
+					if s.GetMessageFilterTimestamp() != nil && msg.GetTimestamp().GetTimeMilli() < s.GetMessageFilterTimestamp().GetTimeMilli() {
 						fnode.State.LogMessage("NetworkInputs", "Drop, too old", msg)
 						continue
 					}

--- a/state/factoidstate.go
+++ b/state/factoidstate.go
@@ -149,6 +149,17 @@ func (fs *FactoidState) EndOfPeriod(period int) {
 }
 
 func (fs *FactoidState) GetCurrentBlock() interfaces.IFBlock {
+	if fs.CurrentBlock == nil {
+		fs.CurrentBlock = factoid.NewFBlock(nil)
+		fs.CurrentBlock.SetExchRate(fs.State.GetFactoshisPerEC())
+		fs.CurrentBlock.SetDBHeight(fs.DBHeight)
+		t := fs.GetCoinbaseTransaction(fs.CurrentBlock.GetDatabaseHeight(), fs.State.GetLeaderTimestamp())
+		err := fs.CurrentBlock.AddCoinbase(t)
+		if err != nil {
+			panic(err.Error())
+		}
+		fs.UpdateTransaction(true, t)
+	}
 	return fs.CurrentBlock
 }
 

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -179,7 +179,7 @@ func (s *State) Validate(msg interfaces.IMsg) (validToSend int, validToExec int)
 	_, ok := s.Replay.Valid(constants.INTERNAL_REPLAY, msg.GetRepeatHash().Fixed(), msg.GetTimestamp(), s.GetTimestamp())
 	if !ok {
 		consenLogger.WithFields(msg.LogFields()).Debug("executeMsg (Replay Invalid)")
-		s.LogMessage("executeMsg", "drop, INTERNAL_REPLAY", msg)
+		s.LogMessage("executeMsg", "drop, INTERNAL_REPLAY2", msg)
 		return -1, -1
 	}
 


### PR DESCRIPTION
This adds a 20 minute grace period for DBsigs, that the other server messages have which was introduced in 6.4.1 for an emergency patch.  

This pull also fixes a pokemon bug and fixes printing of some timestamps 