### PR TITLE
Make API pick the right server instance

### DIFF
--- a/wsapi/wsapi.go
+++ b/wsapi/wsapi.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -93,15 +92,10 @@ func SetState(state interfaces.IState) {
 }
 
 func GetState(r *http.Request) (state interfaces.IState, err error) {
-	_, port, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to extract port from request: %s", err))
-	}
-
+	ServersMutex.Lock()
+	defer ServersMutex.Unlock()
+	port := r.Header.Get("factomd-port")
 	if server, ok := Servers[port]; ok {
-		ServersMutex.Lock()
-		defer ServersMutex.Unlock()
-
 		return server.State, nil
 	} else {
 		return nil, errors.New(fmt.Sprintf("failed to get state, server initialization on port: %s failed", port))


### PR DESCRIPTION
TL;DR make the http request always able to get the right Server instance instead of relying on user input

This was a problem that occurred for @ilzheev's open node when updating from 6.4.1 to 6.4.3. The API returned a 400 error when requests were routed through a proxy, but were fine when accessing the endpoint directly. 

The issue is that 6.4.3 introduces a change of how the "Server" is retrieved. In [wsapi/wsapi.go](https://github.com/FactomProject/factomd/blob/bb94084344fd919185d065bef2662d69087ea293/wsapi/wsapi.go), the start/stop/set functions store the "Server" by the associated State's port, which is used in unit testing to create several different test instances on different ports. In a normal node, the Server gets stored in "8090".

Before 6.4.3, the Server was stored in the request's context. In 6.4.3, the code tries to extract the correct port from the **http `Host` field**: https://github.com/FactomProject/factomd/blob/bb94084344fd919185d065bef2662d69087ea293/wsapi/wsapi.go#L95-L99

This work under normal circumstances, but in the Open Node, http requests were proxied, meaning they arrived at the factomd node with a different `Host` value containing a different port than what factomd runs on. The issue has been patched in the open node by getting the proxy to override the Host field with one that includes the expected port.

This PR is a more general fix. Since the code at the moment uses only the "request" to retrieve the state and reworking the structure of wsapi would have required significant effort, I felt that the easiest way would be just for the web server to tag its port onto the request as a http header variable "factomd-port" via middleware. 

This means a web server will always embed the "port" value that is associated with that instance's entry in the "Servers" map, regardless of what the http Host field is.

