### PR TITLE
adjust thread waitgroups

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -88,7 +88,6 @@ func (p *process) bindCallbacks(w *worker.Thread, initHandler worker.Handle) {
 		p.doneWait.Wait()
 		w.Call(worker.COMPLETE)
 		p.exitWait.Done()
-		p.exitWait.Wait()
 	}()
 
 }


### PR DESCRIPTION
Adjust thread groups to assume OnExit will cause the running goroutine to exit

Ensure OnComplete is run for all threads

also adjusted to use only 2 goroutines per 'thread' - one for running and one for exit