### PR TITLE
Add msg/ack delay prometheus metrics

### DIFF
--- a/common/interfaces/msg.go
+++ b/common/interfaces/msg.go
@@ -5,6 +5,8 @@
 package interfaces
 
 import (
+	"time"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -44,6 +46,10 @@ type IMsg interface {
 
 	// Returns the timestamp for a message
 	GetTimestamp() Timestamp
+
+	// Timestamps of when we received the message locally
+	GetReceivedTime() time.Time
+	SetReceivedTime(time time.Time)
 
 	// This is the hash used to check for repeated messages.  Almost always this
 	// is the MsgHash, however for Chain Commits, Entry Commits, and Factoid Transactions,

--- a/common/messages/msgbase/MessageBase.go
+++ b/common/messages/msgbase/MessageBase.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/interfaces"
@@ -40,6 +41,19 @@ type MessageBase struct {
 	Stalled     bool // This message is currently stalled
 	MarkInvalid bool
 	Sigvalid    bool
+
+	// The time the message was received by our node
+	// Use time.Time vs Timestamp so we don't have to deal with nils
+	// Also the code that adds this timestamp already has the time.Time
+	LocalReceived time.Time
+}
+
+func (m *MessageBase) GetReceivedTime() time.Time {
+	return m.LocalReceived
+}
+
+func (m *MessageBase) SetReceivedTime(time time.Time) {
+	m.LocalReceived = time
 }
 
 func (m *MessageBase) StringOfMsgBase() string {

--- a/engine/NetworkProcessorNet.go
+++ b/engine/NetworkProcessorNet.go
@@ -165,6 +165,8 @@ func Peers(fnode *FactomNode) {
 					// Receive is not blocking; nothing to do, we get a nil.
 					break // move to next peer
 				}
+				msg.SetReceivedTime(preReceiveTime)
+
 				if err != nil {
 					fnode.State.LogPrintf("NetworkInputs", "error on receive from %v: %v", peer.GetNameFrom(), err)
 					// TODO: Maybe we should check the error type and/or count errors and change status to offline?

--- a/state/instrumentation.go
+++ b/state/instrumentation.go
@@ -261,6 +261,26 @@ var (
 		Name: "factomd_state_execute_msg_time",
 		Help: "Time spent in executeMsg",
 	})
+
+	//		Eom/DBSig delay
+	LeaderSyncAckDelay = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "factomd_state_consensus_sync_delay_ack_vec_sec",
+		Help: "Instruments the delay in the time an ack (eom/dbsig only) was signed by a leader, " +
+			"and the time it took our node to receive it in nanoseconds.",
+	}, []string{"leader"})
+
+	LeaderSyncMsgDelay = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "factomd_state_consensus_sync_delay_msg_vec_sec",
+		Help: "Instruments the delay in the time a msg (eom/dbsig only) was signed by a leader, " +
+			"and the time it took our node to receive it in nanoseconds.",
+	}, []string{"leader"})
+
+	LeaderSyncAckPairDelay = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "factomd_state_consensus_ackpair_delay_vec_sec",
+		Help: "Instruments the delay in the time an ack & msg pair was received. " +
+			"If there is a delay, it means the ack+msg would benefit from being " +
+			"coupled. The delay is measured in seconds.",
+	}, []string{"leader"})
 )
 
 var registered bool = false
@@ -352,4 +372,8 @@ func RegisterPrometheus() {
 	prometheus.MustRegister(TotalEmptyLoopTime)
 	prometheus.MustRegister(TotalAckLoopTime)
 	prometheus.MustRegister(TotalExecuteMsgTime)
+	//		Delays
+	prometheus.MustRegister(LeaderSyncMsgDelay)
+	prometheus.MustRegister(LeaderSyncAckDelay)
+	prometheus.MustRegister(LeaderSyncAckPairDelay)
 }


### PR DESCRIPTION
This allows better analysis of the timing delay
of follower to the various leaders on the network.
This allows some basic latency tests to be done
on a follower following the blockchain.

(Only done for Eoms)