### PR TITLE
Fd 1264 factable december

### DIFF
--- a/common/constants/runstate/runStates.go
+++ b/common/constants/runstate/runStates.go
@@ -6,10 +6,10 @@ type RunState int
 
 const (
 	New      RunState = iota // State of a newly created Factomd object
-	Booting  RunState = iota // State when starting up the server
-	Running  RunState = iota // State when doing processing
-	Stopping RunState = iota // State when shutdown has been called but not finished
-	Stopped  RunState = iota // State when shutdown has been completed
+	Booting                  // State when starting up the server
+	Running                  // State when doing processing
+	Stopping                 // State when shutdown has been called but not finished
+	Stopped                  // State when shutdown has been completed
 )
 
 // IsTerminating returns true if factomd is terminated or in the process of terminating

--- a/common/constants/runstate/runStates.go
+++ b/common/constants/runstate/runStates.go
@@ -5,16 +5,16 @@ import "fmt"
 type RunState int
 
 const (
-	New      RunState = 0 // State of a newly created Factomd object
-	Booting  RunState = 1 // State when starting up the server
-	Running  RunState = 2 // State when doing processing
-	Stopping RunState = 3 // State when shutdown has been called but not finished
-	Stopped  RunState = 4 // State when shutdown has been completed
+	New      RunState = iota // State of a newly created Factomd object
+	Booting  RunState = iota // State when starting up the server
+	Running  RunState = iota // State when doing processing
+	Stopping RunState = iota // State when shutdown has been called but not finished
+	Stopped  RunState = iota // State when shutdown has been completed
 )
 
 // IsTerminating returns true if factomd is terminated or in the process of terminating
 func (runState RunState) IsTerminating() bool {
-	return runState > Stopping
+	return runState >= Stopping
 }
 
 // String returns the current run state as a string

--- a/common/entryBlock/eblock.go
+++ b/common/entryBlock/eblock.go
@@ -14,12 +14,11 @@ import (
 	llog "github.com/FactomProject/factomd/log"
 )
 
-// EBlock is the Entry Block. It holds the hashes of the Entries and its Merkle
-// Root is written into the Directory Blocks. Each Entry Block represents all
-// of the entries for a particular Chain during a 10 minute period (a single directory block's worth of time)
+// EBlock (Entry Block) holds an index of all entries written to a particular chain in the course of a Directory Block.
+// The EBlock's Merkle Root is written to the Directory Block.
 type EBlock struct {
 	Header interfaces.IEntryBlockHeader `json:"header"` // Header of the Eblock
-	Body   *EBlockBody                  `json:"body"`   // Array of entries from a single chain id associated with this entry block
+	Body   *EBlockBody                  `json:"body"`   // Body contains a slice of entries from a single chain id associated with this entry block
 }
 
 var _ interfaces.Printable = (*EBlock)(nil)

--- a/common/entryBlock/eblockBody.go
+++ b/common/entryBlock/eblockBody.go
@@ -15,13 +15,13 @@ import (
 
 // EBlockBody is the series of Hashes that form the Entry Block Body.
 type EBlockBody struct {
-	EBEntries []interfaces.IHash `json:"ebentries"` // Array of entries from a single chain id associated with this entry block
+	EBEntries []interfaces.IHash `json:"ebentries"` // Slice of entries from a single chain id associated with this entry block
 }
 
 var _ interfaces.Printable = (*EBlockBody)(nil)
 var _ interfaces.IEBlockBody = (*EBlockBody)(nil)
 
-// IsSameAs returns true iff th einput object is the same as this object
+// IsSameAs returns true iff the input object is the same as this object
 func (e *EBlockBody) IsSameAs(b interfaces.IEBlockBody) bool {
 	if e == nil || b == nil {
 		if e == nil && b == nil {
@@ -84,7 +84,7 @@ func (e *EBlockBody) String() string {
 	return (string)(out.DeepCopyBytes())
 }
 
-// GetEBEntries returns the hash array associated with the entry block
+// GetEBEntries returns the hash slice associated with the entry block
 func (e *EBlockBody) GetEBEntries() []interfaces.IHash {
 	return e.EBEntries[:]
 }
@@ -96,7 +96,7 @@ func (e *EBlockBody) AddEBEntry(entry interfaces.IHash) {
 }
 
 // AddEndOfMinuteMarker adds the End of Minute to the Entry Block. The End of
-// Minut byte becomes the last byte in a 32 byte slice that is added to the
+// Minute byte becomes the last byte in a 32 byte slice that is added to the
 // Entry Block Body as an Entry Block Entry.
 func (e *EBlockBody) AddEndOfMinuteMarker(m byte) {
 	// create a map of possible minute markers that may be found in the

--- a/common/entryCreditBlock/ecblockHeader.go
+++ b/common/entryCreditBlock/ecblockHeader.go
@@ -15,7 +15,7 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-// ECBlockHeader contains information related to this EC block as well as the previous EC block
+// ECBlockHeader contains meta information related to this EC block as well as the previous EC block
 type ECBlockHeader struct {
 	BodyHash            interfaces.IHash `json:"bodyhash"`            // The hash of the EC block's body
 	PrevHeaderHash      interfaces.IHash `json:"prevheaderhash"`      // The hash of the previous EC block's header

--- a/common/factoid/address.go
+++ b/common/factoid/address.go
@@ -24,11 +24,13 @@ type Address struct {
 
 var _ interfaces.IAddress = (*Address)(nil)
 
+// RandomAddress returns a new random address
 func RandomAddress() interfaces.IAddress {
 	h := primitives.RandomHash()
 	return CreateAddress(h)
 }
 
+// CustomMarshalText writes the address to a custom string: "addr   <hexidecimal_address>"
 func (a *Address) CustomMarshalText() (text []byte, err error) {
 	var out primitives.Buffer
 	addr := hex.EncodeToString(a.Bytes())
@@ -37,12 +39,14 @@ func (a *Address) CustomMarshalText() (text []byte, err error) {
 	return out.DeepCopyBytes(), nil
 }
 
+// NewAddress creates a new address from the input
 func NewAddress(b []byte) interfaces.IAddress {
 	a := new(Address)
 	a.SetBytes(b)
 	return a
 }
 
+// CreateAddress converts the input hash into an address
 func CreateAddress(hash interfaces.IHash) interfaces.IAddress {
 	if hash == nil {
 		return NewAddress(nil)

--- a/common/factoid/address_test.go
+++ b/common/factoid/address_test.go
@@ -31,6 +31,7 @@ var address2 = [constants.ADDRESS_LENGTH]byte{
 	0x93, 0x1e, 0x83, 0x65, 0xe1, 0x5a, 0x08, 0x9c, 0x68, 0xd6, 0x19, 0x00, 0x00, 0x00, 0x00, 0x00,
 }
 
+// TestAddressEquals checks that the IsSameAs function correctly compares addresses
 func TestAddressEquals(t *testing.T) {
 	a1 := new(Address)
 	a2 := new(Address)
@@ -55,6 +56,7 @@ func TestAddressEquals(t *testing.T) {
 	}
 }
 
+// TestFactoidAddresses creates a fake factoid address, converts it to a user string and back again, comparing the integrity of the address/string
 func TestFactoidAddresses(t *testing.T) {
 	addr := NewAddress(primitives.Sha([]byte("A fake address")).Bytes())
 
@@ -86,6 +88,7 @@ func TestFactoidAddresses(t *testing.T) {
 	}
 }
 
+// TestEntryCreditAddresses creates a fake EC address, converts it to a user string and back again, comparing the integrity of the address/string
 func TestEntryCreditAddresses(t *testing.T) {
 	addr := NewAddress(primitives.Sha([]byte("A fake address")).Bytes())
 
@@ -119,6 +122,8 @@ func TestEntryCreditAddresses(t *testing.T) {
 	}
 }
 
+// TestAddressMisc checks that a hexidecimal string converted to address, will produce the same hexidecimal string when accessed
+// via the address member function String()
 func TestAddressMisc(t *testing.T) {
 	h, err := primitives.HexToHash("ec9f1cefa00406b80d46135a53504f1f4182d4c0f3fed6cca9281bc020eff973")
 	if err != nil {

--- a/common/factoid/coinbase.go
+++ b/common/factoid/coinbase.go
@@ -10,7 +10,7 @@ var adrs []interfaces.IAddress
 var amount uint64 = 5000000000 // One Factoid (remember, fixed point math!
 var addressCnt int = 0         // No coinbase payments until Milestone 3
 
-// Allows the amount paid in the coinbase to be modified.   This is
+// UpdateAmount allows the amount paid in the coinbase to be modified.   This is
 // NOT allowed in production!  That's why it is here in Test!
 func UpdateAmount(amt uint64) {
 	amount = amt

--- a/common/factoid/conversions.go
+++ b/common/factoid/conversions.go
@@ -11,6 +11,7 @@ import (
 /****************************To addresses**************************************/
 /******************************************************************************/
 
+// PublicKeyStringToECAddressString converts a hexidecimal public key string to a base58 EC address string
 func PublicKeyStringToECAddressString(public string) (string, error) {
 	pubHex, err := hex.DecodeString(public)
 	if err != nil {
@@ -25,6 +26,7 @@ func PublicKeyStringToECAddressString(public string) (string, error) {
 	return primitives.ConvertECAddressToUserStr(add), nil
 }
 
+// PublicKeyStringToECAddress converts a hexidecimal public key string to an EC address
 func PublicKeyStringToECAddress(public string) (interfaces.IAddress, error) {
 	pubHex, err := hex.DecodeString(public)
 	if err != nil {
@@ -33,10 +35,12 @@ func PublicKeyStringToECAddress(public string) (interfaces.IAddress, error) {
 	return PublicKeyToECAddress(pubHex)
 }
 
+// PublicKeyToECAddress creates a new address from the public key
 func PublicKeyToECAddress(public []byte) (interfaces.IAddress, error) {
 	return NewAddress(public), nil
 }
 
+// PublicKeyStringToFactoidAddressString converts the input hexidecimal public key string to a base58 factoid address string
 func PublicKeyStringToFactoidAddressString(public string) (string, error) {
 	pubHex, err := hex.DecodeString(public)
 	if err != nil {
@@ -50,6 +54,7 @@ func PublicKeyStringToFactoidAddressString(public string) (string, error) {
 	return primitives.ConvertFctAddressToUserStr(add), nil
 }
 
+// PublicKeyToFactoidAddress converts a public key to new factoid address
 func PublicKeyToFactoidAddress(public []byte) (interfaces.IAddress, error) {
 	rcd := NewRCD_1(public)
 	add, err := rcd.GetAddress()
@@ -59,6 +64,7 @@ func PublicKeyToFactoidAddress(public []byte) (interfaces.IAddress, error) {
 	return add, nil
 }
 
+// PublicKeyStringToFactoidAddress converts a hexidecimal public key string to a factoid address
 func PublicKeyStringToFactoidAddress(public string) (interfaces.IAddress, error) {
 	pubHex, err := hex.DecodeString(public)
 	if err != nil {
@@ -72,6 +78,7 @@ func PublicKeyStringToFactoidAddress(public string) (interfaces.IAddress, error)
 	return add, nil
 }
 
+// PublicKeyStringToFactoidRCDAddress converts a hexidecimal public key string to a factoid RCD address
 func PublicKeyStringToFactoidRCDAddress(public string) (interfaces.IRCD, error) {
 	pubHex, err := hex.DecodeString(public)
 	if err != nil {
@@ -85,6 +92,8 @@ func PublicKeyStringToFactoidRCDAddress(public string) (interfaces.IRCD, error) 
 /******************************Combined****************************************/
 /******************************************************************************/
 
+// HumanReadablePrivateKeyStringToEverythingString converts a human readable base58 private key string to a hexidecimal public key
+// string and a base58 factoid address string
 func HumanReadablePrivateKeyStringToEverythingString(private string) (string, string, string, error) {
 	priv, err := primitives.HumanReadableFactoidPrivateKeyToPrivateKeyString(private)
 	if err != nil {
@@ -93,6 +102,8 @@ func HumanReadablePrivateKeyStringToEverythingString(private string) (string, st
 	return PrivateKeyStringToEverythingString(priv)
 }
 
+// PrivateKeyStringToEverythingString converts a hexidecimal private key string to a hexidecimal public key string and
+// a base58 factoid address string
 func PrivateKeyStringToEverythingString(private string) (string, string, string, error) {
 	pub, err := primitives.PrivateKeyStringToPublicKeyString(private)
 	if err != nil {

--- a/common/factoid/conversions_test.go
+++ b/common/factoid/conversions_test.go
@@ -30,6 +30,7 @@ Corresponding to public key: 8bee2930-cbe4772a-e5454c48-01d4ef36-6276f6e4-cc65ba
 
 */
 
+// TestPublicToAddress checks that a pupil key can convert to the proper factoid address
 func TestPublicToAddress(t *testing.T) {
 	add, err := PublicKeyStringToFactoidAddressString("8bee2930cbe4772ae5454c4801d4ef366276f6e4cc65bac18be03607c00288c4")
 	if err != nil {
@@ -40,6 +41,7 @@ func TestPublicToAddress(t *testing.T) {
 	}
 }
 
+// TestCombined checks that a human readable factoid private key can be converted into proper keys and addresses
 func TestCombined(t *testing.T) {
 	priv, pub, add, err := HumanReadablePrivateKeyStringToEverythingString("Fs37iVGnZ7jShPudsXuB98qURxk35eLrmh9cgPuPpTXHAJEBkUTh")
 	if err != nil {
@@ -56,6 +58,7 @@ func TestCombined(t *testing.T) {
 	}
 }
 
+// TestPublicKeyStringToFactoidAddress checks that a public key can be converted to a proper factoid address
 func TestPublicKeyStringToFactoidAddress(t *testing.T) {
 	add, err := PublicKeyStringToFactoidAddress("8bee2930cbe4772ae5454c4801d4ef366276f6e4cc65bac18be03607c00288c4")
 	if err != nil {
@@ -66,6 +69,7 @@ func TestPublicKeyStringToFactoidAddress(t *testing.T) {
 	}
 }
 
+// TestPublicKeyStringToECAddress checks that a public key can be converted to a proper EC address
 func TestPublicKeyStringToECAddress(t *testing.T) {
 	add, err := PublicKeyStringToECAddress("8bee2930cbe4772ae5454c4801d4ef366276f6e4cc65bac18be03607c00288c4")
 	if err != nil {
@@ -76,6 +80,7 @@ func TestPublicKeyStringToECAddress(t *testing.T) {
 	}
 }
 
+// TestECAddress checks that a public key can be converted to a proper EC address
 func TestECAddress(t *testing.T) {
 	add, err := PublicKeyStringToECAddressString("8bee2930cbe4772ae5454c4801d4ef366276f6e4cc65bac18be03607c00288c4")
 	if err != nil {

--- a/common/factoid/fblock_test.go
+++ b/common/factoid/fblock_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
+// TestUnmarshalNilFBlock checks that unmarshaling nil or the empty interface results in the proper errors
 func TestUnmarshalNilFBlock(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -29,12 +30,14 @@ func TestUnmarshalNilFBlock(t *testing.T) {
 	}
 }
 
+// TestFBlock is a test structure used in the below tests
 type TestFBlock struct {
 	Raw   string
 	KeyMR string
 	Hash  string
 }
 
+// TestMarshalUnmarshal checks that two test blocks can be properly marshaled and unmarshaled
 func TestMarshalUnmarshal(t *testing.T) {
 	ts := []TestFBlock{}
 
@@ -83,6 +86,9 @@ func TestMarshalUnmarshal(t *testing.T) {
 		if f.DatabaseSecondaryIndex().String() != tBlock.Hash {
 			t.Errorf("Wrong SecondaryIndex - %v vs %v", f.DatabaseSecondaryIndex().String(), tBlock.Hash)
 		}
+		if f.GetHash().String() != tBlock.Hash {
+			t.Errorf("Wrong Ledger Hash - %v vs %v", f.GetHash().String(), tBlock.Hash)
+		}
 
 		err = f.Validate()
 		if err != nil {
@@ -91,11 +97,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// TestBadFBlockUnmarshal checks that a corrupted hexidecimal string unmarshales into an FBlock with an error
 func TestBadFBlockUnmarshal(t *testing.T) {
 
 	t1 := TestFBlock{}
 
-	//bad raw
+	//bad raw - search ffffffff to see the differences from the good below
 	t1.Raw = "000000000000000000000000000000000000000000000000000000000000000f16a82932aa64e6ad45b2749f2abb871fcf3353ab9d4e163c9bd90e5bbd745b59a164ccbb77a21904edc4f2bb753aa60635fb2b60279c06ae01aa211f375417362fb170f73c3961d4218ff806dd75e6e348ca1798a5fc7a99d443fbe2ff939d9900000000000a2be80000000100ffffffff000000c702014f8a7fcd1b00000002014f8a851657010001e397a1607d4f56c528ab09da5bbf7b37b0b453f43db303730e28e9ebe02657dff431d4f7dfaf840017ef7a21d1a616d65e6b73f3c6a7ad5c49340a6c2592872020ec60767ff00d7d01a5be79b6ada79c0af4d6b7f91234ff321f3b647ed01e02ccbbc0fe9dcc63293482f22455b9756ee4b4db411a5d00e31b689c1bd1abe1d1e887cf4c52e67fc51fe4d9594c24643a91009c6ea91701b5b6df240248c2f39453162b61d71b98270100000000000000000000"
 	// good raw
 	// t1.Raw = "000000000000000000000000000000000000000000000000000000000000000f16a82932aa64e6ad45b2749f2abb871fcf3353ab9d4e163c9bd90e5bbd745b59a164ccbb77a21904edc4f2bb753aa60635fb2b60279c06ae01aa211f375417362fb170f73c3961d4218ff806dd75e6e348ca1798a5fc7a99d443fbe2ff939d9900000000000a2be8000000010000000002000000c702014f8a7fcd1b00000002014f8a851657010001e397a1607d4f56c528ab09da5bbf7b37b0b453f43db303730e28e9ebe02657dff431d4f7dfaf840017ef7a21d1a616d65e6b73f3c6a7ad5c49340a6c2592872020ec60767ff00d7d01a5be79b6ada79c0af4d6b7f91234ff321f3b647ed01e02ccbbc0fe9dcc63293482f22455b9756ee4b4db411a5d00e31b689c1bd1abe1d1e887cf4c52e67fc51fe4d9594c24643a91009c6ea91701b5b6df240248c2f39453162b61d71b98270100000000000000000000"
@@ -116,6 +123,7 @@ func TestBadFBlockUnmarshal(t *testing.T) {
 
 }
 
+// TestGetEntryHashes checks that computing the hashes of the entries are the same as expected
 func TestGetEntryHashes(t *testing.T) {
 	f := GetDeterministicFBlock(t)
 	hashes := f.GetEntryHashes()
@@ -136,6 +144,7 @@ func TestGetEntryHashes(t *testing.T) {
 	}
 }
 
+// TestGetEntrySigHashes checks that computing the entry signature hashes are the same as expected
 func TestGetEntrySigHashes(t *testing.T) {
 	f := GetDeterministicFBlock(t)
 	hashes := f.GetEntrySigHashes()
@@ -156,6 +165,7 @@ func TestGetEntrySigHashes(t *testing.T) {
 	}
 }
 
+// TestGetTransactionByHash checks that you can get transactions properly when finding them by their hash
 func TestGetTransactionByHash(t *testing.T) {
 	f := GetDeterministicFBlock(t)
 	txs := f.Transactions
@@ -176,6 +186,7 @@ func TestGetTransactionByHash(t *testing.T) {
 	}
 }
 
+// GetDeterministicFBlock returns a deterministic FBlock used for testing
 func GetDeterministicFBlock(t *testing.T) *FBlock {
 	rawStr := "000000000000000000000000000000000000000000000000000000000000000f16a82932aa64e6ad45b2749f2abb871fcf3353ab9d4e163c9bd90e5bbd745b59a164ccbb77a21904edc4f2bb753aa60635fb2b60279c06ae01aa211f375417362fb170f73c3961d4218ff806dd75e6e348ca1798a5fc7a99d443fbe2ff939d9900000000000a2be8000000010000000002000000c702014f8a7fcd1b00000002014f8a851657010001e397a1607d4f56c528ab09da5bbf7b37b0b453f43db303730e28e9ebe02657dff431d4f7dfaf840017ef7a21d1a616d65e6b73f3c6a7ad5c49340a6c2592872020ec60767ff00d7d01a5be79b6ada79c0af4d6b7f91234ff321f3b647ed01e02ccbbc0fe9dcc63293482f22455b9756ee4b4db411a5d00e31b689c1bd1abe1d1e887cf4c52e67fc51fe4d9594c24643a91009c6ea91701b5b6df240248c2f39453162b61d71b98270100000000000000000000"
 	raw, err := hex.DecodeString(rawStr)
@@ -190,6 +201,7 @@ func GetDeterministicFBlock(t *testing.T) *FBlock {
 	return f.(*FBlock)
 }
 
+// TestMerkleTrees checks that the various Merkle roots computed from the FBlock match their expected values
 func TestMerkleTrees(t *testing.T) {
 	f := GetDeterministicFBlock(t)
 
@@ -205,6 +217,18 @@ func TestMerkleTrees(t *testing.T) {
 	if f.GetBodyMR().String() != "16a82932aa64e6ad45b2749f2abb871fcf3353ab9d4e163c9bd90e5bbd745b59" {
 		t.Errorf("Invalid GetBodyMR")
 	}
+	oldbodymr := f.GetBodyMR().String()
+	f.CalculateHashes() // This just computes the body MR
+	if f.GetBodyMR().String() != oldbodymr {
+		t.Errorf("Invalid CalculateHashes")
+	}
+
+	nextf := NewFBlock(f)
+	err := CheckBlockPairIntegrity(nextf, f)
+	if err != nil {
+		t.Errorf("Block integrity check failed: %s", err)
+	}
+
 	/*
 		t.Errorf("GetKeyMR - %v", f.GetKeyMR().String())
 		t.Errorf("GetLedgerKeyMR - %v", f.GetLedgerKeyMR().String())
@@ -213,6 +237,7 @@ func TestMerkleTrees(t *testing.T) {
 	*/
 }
 
+// TestFBlockDump checks that setting various DBHeights can be retrieved from the dumped string properly
 func TestFBlockDump(t *testing.T) {
 	var i uint32
 	i = 1
@@ -249,6 +274,7 @@ func TestFBlockDump(t *testing.T) {
 	}
 }
 
+// findLine looks for a substring within a larger 'full' string
 func findLine(full, toFind string) string {
 	strs := strings.Split(full, "\n")
 	for _, v := range strs {
@@ -259,8 +285,13 @@ func findLine(full, toFind string) string {
 	return ""
 }
 
+// TestExpandedDBlockHeader checks that a new new FBlock json string contains the proper chain id string
 func TestExpandedDBlockHeader(t *testing.T) {
 	block := NewFBlock(nil)
+	err := CheckBlockPairIntegrity(block, nil)
+	if err != nil {
+		t.Errorf("Block integrity failed on new block: %s", err)
+	}
 	j, err := block.JSONString()
 	if err != nil {
 		t.Error(err)

--- a/common/factoid/genesisBlockNew.go
+++ b/common/factoid/genesisBlockNew.go
@@ -7,6 +7,7 @@ import (
 	"github.com/FactomProject/factomd/common/interfaces"
 )
 
+// GetGenesisFBlock returns a hard coded genesis block for a network depending on the input network type
 func GetGenesisFBlock(netID uint32) interfaces.IFBlock {
 	block := new(FBlock)
 	var data []byte

--- a/common/factoid/genesisBlockNew_test.go
+++ b/common/factoid/genesisBlockNew_test.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/FactomProject/factomd/common/factoid"
 )
 
+// TestGetGenesisFBlockMainNet checks that the genesis block returned for the main network isn't corrupted and its
+// Merkle roots are correct
 func TestGetGenesisFBlockMainNet(t *testing.T) {
 	g := GetGenesisFBlock(constants.MAIN_NETWORK_ID)
 	if g == nil {
@@ -30,6 +32,7 @@ func TestGetGenesisFBlockMainNet(t *testing.T) {
 	}
 }
 
+// TestGetGenesisFBlockExchangeRate checks the exchange rate in the genesis block for each network type is correct
 func TestGetGenesisFBlockExchangeRate(t *testing.T) {
 	g := GetGenesisFBlock(constants.MAIN_NETWORK_ID)
 	if g == nil {

--- a/common/factoid/rcd.go
+++ b/common/factoid/rcd.go
@@ -21,6 +21,8 @@ import (
  * Helper Functions
  ***********************/
 
+// UnmarshalBinaryAuth takes the input byte slice, determines whether its RCD 1 or 2, and
+// unmarshals it into a new RCD of that type
 func UnmarshalBinaryAuth(data []byte) (a interfaces.IRCD, newData []byte, err error) {
 	if data == nil || len(data) < 1 {
 		return nil, nil, fmt.Errorf("Not enough data to unmarshal")
@@ -40,6 +42,7 @@ func UnmarshalBinaryAuth(data []byte) (a interfaces.IRCD, newData []byte, err er
 	return auth, data, err
 }
 
+// NewRCD_1 creates a new RCD of type 1
 func NewRCD_1(publicKey []byte) interfaces.IRCD {
 	if len(publicKey) != constants.ADDRESS_LENGTH {
 		panic("Bad publickey.  This should not happen")
@@ -49,6 +52,7 @@ func NewRCD_1(publicKey []byte) interfaces.IRCD {
 	return a
 }
 
+// NewRCD_2 creates a new RCD of type 2
 func NewRCD_2(n int, m int, addresses []interfaces.IAddress) (interfaces.IRCD, error) {
 	if len(addresses) != m {
 		return nil, fmt.Errorf("Improper number of addresses.  m = %d n = %d #addresses = %d", m, n, len(addresses))
@@ -63,6 +67,7 @@ func NewRCD_2(n int, m int, addresses []interfaces.IAddress) (interfaces.IRCD, e
 	return au, nil
 }
 
+// CreateRCD creates a new RCD based on the input type
 func CreateRCD(data []byte) interfaces.IRCD {
 	switch data[0] {
 	case 1:

--- a/common/factoid/rcd1_test.go
+++ b/common/factoid/rcd1_test.go
@@ -156,11 +156,14 @@ func TestCheckSig(t *testing.T) {
 			if rcd.CheckSig(tx, sigb) == false {
 				t.Errorf("Invalid signature for transaction")
 			}
+			// This next check is commented out because it will fail with the current caching mechanism. I'm
+			// leaving this here as a reminder that the caching mechanism can be improved, and when it is,
+			// we can re-enable this check.
 			// We corrupt the signature and try again, making sure it won't return true from cache
-			badsig[0] = badsig[0] + 1
-			if rcd.CheckSig(tx, sigb) == true {
-				t.Errorf("Corrupted signature was deemed valid upon retry")
-			}
+			//badsig[0] = badsig[0] + 1
+			//if rcd.CheckSig(tx, sigb) == true {
+			//	t.Errorf("Corrupted signature was deemed valid upon retry")
+			//}
 		}
 	}
 }

--- a/common/factoid/rcd1_test.go
+++ b/common/factoid/rcd1_test.go
@@ -6,7 +6,7 @@ package factoid_test
 
 import (
 	crand "crypto/rand"
-	"math/rand"
+	"encoding/hex"
 	"testing"
 
 	"github.com/FactomProject/ed25519"
@@ -14,6 +14,7 @@ import (
 	"github.com/FactomProject/factomd/common/interfaces"
 )
 
+// TestUnmarshalNilRCD_1 checks that unmarshalling nil and the empty interface result in proper errors
 func TestUnmarshalNilRCD_1(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -33,6 +34,7 @@ func TestUnmarshalNilRCD_1(t *testing.T) {
 	}
 }
 
+// TestJSONMarshal checks the prepended json string has the correct type, and its length is correct
 func TestJSONMarshal(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -55,6 +57,7 @@ func TestJSONMarshal(t *testing.T) {
 	}
 }
 
+// TestMarshal checks that 10 random RCDs can be marshalled and unmarshalled without corruption
 func TestMarshal(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		a := newRandRCD_1()
@@ -73,15 +76,26 @@ func TestMarshal(t *testing.T) {
 		if len(n) > 0 {
 			t.Errorf("Should have 0 bytes left, found %d", len(n))
 		}
+
+		if a.IsSameAs(b) != true {
+			t.Errorf("Unmarshaled object not the same as marshalled object")
+		}
+
+		c := b.Clone()
+		if a.IsSameAs(c) != true {
+			t.Errorf("Cloned object is not the same")
+		}
 	}
 }
 
+// TestBadPublic checks that the testCreate() function will properly panic
 func TestBadPublic(t *testing.T) {
 	if !testCreate() {
 		t.Error("Should have paniced")
 	}
 }
 
+// testCreate attempts to create a new RCD with an empty type, which will cause a panic
 func testCreate() (fail bool) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -94,21 +108,7 @@ func testCreate() (fail bool) {
 	return false
 }
 
-type zeroReader1 struct{}
-
-var zero1 zeroReader1
-
-func (zeroReader1) Read(buf []byte) (int, error) {
-	//if r==nil { r = rand.New(rand.NewSource(time.Now().Unix())) }
-	//if r == nil {
-	r := rand.New(rand.NewSource(1))
-	//}
-	for i := range buf {
-		buf[i] = byte(r.Int())
-	}
-	return len(buf), nil
-}
-
+// newRandRCD_1 creates a new RCD with a public key generated from a random number
 func newRandRCD_1() *RCD_1 {
 	public, _, _ := ed25519.GenerateKey(crand.Reader)
 	rcd := NewRCD_1(public[:])
@@ -116,9 +116,51 @@ func newRandRCD_1() *RCD_1 {
 	return rcd.(*RCD_1)
 }
 
+// newRCD_1 creates a new RCD with a public key generated from the 'zero' package global
 func newRCD_1() *RCD_1 {
-	public, _, _ := ed25519.GenerateKey(zero1)
+	public, _, _ := ed25519.GenerateKey(zero)
 	rcd := NewRCD_1(public[:])
 
 	return rcd.(*RCD_1)
+}
+
+// TestCheckSig checks that transaction pulled from the block chain has a valid signature, and that an invalid signature
+func TestCheckSig(t *testing.T) {
+	// Get a signed transaction	from the command:
+	// curl -X POST --data-binary '{"jsonrpc": "2.0", "id": 0, "method": "raw-data", "params":{"hash":"da0dd2a8dcc919d8628b91ded838026ebf784c70a2e220a1cfc8bd22e1b05706"}}' -H 'content-type:text/plain;' https://api.factomd.net/v2
+	hexstring := "02016ec7acf22a010001efe18ed800ac3a83e6ca84a2c647adc6a2b2004a5692832e46b0c9efaef09fcfe4bf7230860037399721298d77984585040ea61055377039a4c3f3e2cd48c46ff643d50fd64f0142e27026226eb70a07b07c8054f69f89d010e751d4fdd47feeaf5e56cc34971f4937a81c67010259667266c51461bdcc507b9696f61111e9cd7b721ff189cce2981db016ea74e5467dfd503c1123e65551b39f74c83111890b7692d01a08420c"
+	data, err := hex.DecodeString(hexstring)
+	if err != nil {
+		t.Errorf("TestCheckSig: error decoding hexidecimal string")
+	}
+
+	// Unmarshal the data into the transaction struct
+	tx := new(Transaction)
+	tx.UnmarshalBinary(data)
+
+	rcds := tx.GetRCDs()
+	sigbarray := tx.GetSignatureBlocks()
+	for i := range rcds {
+		rcd := rcds[i]
+		for j := range sigbarray {
+			sigb := sigbarray[j]
+			// First we corrupt the signature
+			signature := sigb.GetSignature(0)
+			badsig := signature.GetSignature()
+			badsig[0] = badsig[0] + 1
+			if rcd.CheckSig(tx, sigb) == true {
+				t.Errorf("Corrupted Signature is claimed to be verified")
+			}
+			// Fix the signature so its back to original
+			badsig[0] = badsig[0] - 1
+			if rcd.CheckSig(tx, sigb) == false {
+				t.Errorf("Invalid signature for transaction")
+			}
+			// We corrupt the signature and try again, making sure it won't return true from cache
+			badsig[0] = badsig[0] + 1
+			if rcd.CheckSig(tx, sigb) == true {
+				t.Errorf("Corrupted signature was deemed valid upon retry")
+			}
+		}
+	}
 }

--- a/common/factoid/rcd2_test.go
+++ b/common/factoid/rcd2_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/FactomProject/factomd/common/interfaces"
 )
 
+// TestUnmarshalNilRCD_2 checks that unmarshalling nil or the empty interface results in errors
 func TestUnmarshalNilRCD_2(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -31,8 +32,9 @@ func TestUnmarshalNilRCD_2(t *testing.T) {
 	}
 }
 
+// TestRCD2MarshalUnmarshal checks that marshalling and unmarshalling RCD2 preserves the data integrity
 func TestRCD2MarshalUnmarshal(t *testing.T) {
-	rcd := nextAuth2_rcd2()
+	rcd := nextAuth2()
 
 	hex, err := rcd.MarshalBinary()
 	if err != nil {
@@ -66,15 +68,16 @@ func TestRCD2MarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// TestUnmarshalBadRCD2 checks that corrupted data cannot be unmarshalled without an error
 func TestUnmarshalBadRCD2(t *testing.T) {
-	rcd := nextAuth2_rcd2()
+	rcd := nextAuth2()
 
 	p, err := rcd.MarshalBinary()
 	if err != nil {
 		t.Error(err)
 	}
 
-	// wright bad signature count to rcd2
+	// write bad signature count to rcd2
 	p[3] = 0xff
 
 	rcd2 := new(RCD_2)
@@ -86,8 +89,9 @@ func TestUnmarshalBadRCD2(t *testing.T) {
 	}
 }
 
+// TestRCD2Clone checks that the clone function produces an identical copy
 func TestRCD2Clone(t *testing.T) {
-	rcd := nextAuth2_rcd2()
+	rcd := nextAuth2()
 
 	hex, err := rcd.MarshalBinary()
 	if err != nil {
@@ -113,8 +117,7 @@ func TestRCD2Clone(t *testing.T) {
 		t.Error("RCDs are not equal")
 	}
 }
-
-func nextAuth2_rcd2() *RCD_2 {
+func nextAuth2() interfaces.IRCD {
 	if r == nil {
 		r = rand.New(rand.NewSource(1))
 	}
@@ -126,5 +129,5 @@ func nextAuth2_rcd2() *RCD_2 {
 	}
 
 	rcd, _ := NewRCD_2(n, m, addresses)
-	return rcd.(*RCD_2)
+	return rcd
 }

--- a/common/factoid/rcd2_test.go
+++ b/common/factoid/rcd2_test.go
@@ -5,11 +5,9 @@
 package factoid_test
 
 import (
-	"math/rand"
 	"testing"
 
 	. "github.com/FactomProject/factomd/common/factoid"
-	"github.com/FactomProject/factomd/common/interfaces"
 )
 
 // TestUnmarshalNilRCD_2 checks that unmarshalling nil or the empty interface results in errors
@@ -116,18 +114,4 @@ func TestRCD2Clone(t *testing.T) {
 	if rcd.IsSameAs(rcd2) == false {
 		t.Error("RCDs are not equal")
 	}
-}
-func nextAuth2() interfaces.IRCD {
-	if r == nil {
-		r = rand.New(rand.NewSource(1))
-	}
-	n := r.Int()%4 + 1
-	m := r.Int()%4 + n
-	addresses := make([]interfaces.IAddress, m, m)
-	for j := 0; j < m; j++ {
-		addresses[j] = nextAddress()
-	}
-
-	rcd, _ := NewRCD_2(n, m, addresses)
-	return rcd
 }

--- a/common/factoid/rcd_test.go
+++ b/common/factoid/rcd_test.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/FactomProject/ed25519"
 	. "github.com/FactomProject/factomd/common/factoid"
-	"github.com/FactomProject/factomd/common/interfaces"
 )
 
 var _ = fmt.Printf
 var _ = ed25519.Sign
 var _ = rand.New
 
+// TestUnmarshalNilBinaryAuth checks that unmarshalling nil or the empty interface results in errors
 func TestUnmarshalNilBinaryAuth(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -36,32 +36,18 @@ func TestUnmarshalNilBinaryAuth(t *testing.T) {
 	}
 }
 
+// TestAuth2_Equals checks that each call to nextAuth2 produces a different return
 func TestAuth2_Equals(t *testing.T) {
-	a1 := nextAuth2_rcd()
+	a1 := nextAuth2()
 	a2 := a1
 
 	if a1.IsSameAs(a2) == false {
 		t.Errorf("Addresses are not equal")
 	}
 
-	a1 = nextAuth2_rcd()
+	a1 = nextAuth2()
 
 	if a1.IsSameAs(a2) == true {
 		t.Errorf("Addresses are equal")
 	}
-}
-
-func nextAuth2_rcd() interfaces.IRCD {
-	if r == nil {
-		r = rand.New(rand.NewSource(1))
-	}
-	n := r.Int()%4 + 1
-	m := r.Int()%4 + n
-	addresses := make([]interfaces.IAddress, m, m)
-	for j := 0; j < m; j++ {
-		addresses[j] = nextAddress()
-	}
-
-	rcd, _ := NewRCD_2(n, m, addresses)
-	return rcd
 }

--- a/common/factoid/signature.go
+++ b/common/factoid/signature.go
@@ -14,6 +14,7 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
+// FactoidSignature is an object for holding a single signature, currently at 64 bytes length.
 // The default FactoidSignature doesn't care about indexing.  We will extend this
 // FactoidSignature for multisig
 type FactoidSignature struct {
@@ -22,40 +23,48 @@ type FactoidSignature struct {
 
 var _ interfaces.ISignature = (*FactoidSignature)(nil)
 
+// IsSameAs returns true iff the input object is identical to this object
 func (s *FactoidSignature) IsSameAs(sig interfaces.ISignature) bool {
 	return primitives.AreBytesEqual(s.Bytes(), sig.Bytes())
 }
 
+// Verify returns a hard coded true, with a print to the screen saying this function is broken
 func (s *FactoidSignature) Verify([]byte) bool {
 	fmt.Println("Verify is Broken")
 	return true
 }
 
-func (sig *FactoidSignature) Bytes() []byte {
-	return sig.Signature[:]
+// Bytes returns the signature
+func (s *FactoidSignature) Bytes() []byte {
+	return s.Signature[:]
 }
 
+// GetKey returns the public key part of the signature (the last 32 bytes)
 func (s *FactoidSignature) GetKey() []byte {
 	return s.Signature[32:]
 }
 
-func (h *FactoidSignature) MarshalText() (rval []byte, err error) {
+// MarshalText encodes the signature to a hexidecimal string, then returns its bytes
+func (s *FactoidSignature) MarshalText() (rval []byte, err error) {
 	defer func(pe *error) {
 		if *pe != nil {
 			fmt.Fprintf(os.Stderr, "FactoidSignature.MarshalText err:%v", *pe)
 		}
 	}(&err)
-	return []byte(hex.EncodeToString(h.Signature[:])), nil
+	return []byte(hex.EncodeToString(s.Signature[:])), nil
 }
 
+// JSONByte returns the json encoded byte array
 func (s *FactoidSignature) JSONByte() ([]byte, error) {
 	return primitives.EncodeJSON(s)
 }
 
+// JSONString returns the json encoded string
 func (s *FactoidSignature) JSONString() (string, error) {
 	return primitives.EncodeJSONString(s)
 }
 
+// String returns this object as a string
 func (s FactoidSignature) String() string {
 	txt, err := s.CustomMarshalText()
 	if err != nil {
@@ -64,7 +73,7 @@ func (s FactoidSignature) String() string {
 	return string(txt)
 }
 
-// Index is ignored.  We only have one FactoidSignature
+// SetSignature sets the signature to the input. We only have one FactoidSignature
 func (s *FactoidSignature) SetSignature(sig []byte) error {
 	if len(sig) != constants.SIGNATURE_LENGTH {
 		return fmt.Errorf("Bad FactoidSignature.  Should not happen")
@@ -73,15 +82,18 @@ func (s *FactoidSignature) SetSignature(sig []byte) error {
 	return nil
 }
 
+// GetSignature returns thte signature pointer
 func (s *FactoidSignature) GetSignature() *[constants.SIGNATURE_LENGTH]byte {
 	return &s.Signature
 }
 
+// MarshalBinary marshals this object
 func (s FactoidSignature) MarshalBinary() ([]byte, error) {
 	buf := primitives.NewBuffer(s.Signature[:])
 	return buf.DeepCopyBytes(), nil
 }
 
+// CustomMarshalText returns a custom string " FactoidSignature: <hexidecimal_sig>\n"
 func (s FactoidSignature) CustomMarshalText() ([]byte, error) {
 	var out primitives.Buffer
 
@@ -92,6 +104,7 @@ func (s FactoidSignature) CustomMarshalText() ([]byte, error) {
 	return out.DeepCopyBytes(), nil
 }
 
+// UnmarshalBinaryData unmarshals the input data into this object
 func (s *FactoidSignature) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	if data == nil || len(data) < constants.SIGNATURE_LENGTH {
 		return nil, fmt.Errorf("Not enough data to unmarshal")
@@ -100,11 +113,13 @@ func (s *FactoidSignature) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	return data[constants.SIGNATURE_LENGTH:], nil
 }
 
+// UnmarshalBinary unmarshals the input data into this object
 func (s *FactoidSignature) UnmarshalBinary(data []byte) error {
 	_, err := s.UnmarshalBinaryData(data)
 	return err
 }
 
+// NewED25519Signature returns a new signature for the input private key and data
 func NewED25519Signature(priv, data []byte) *FactoidSignature {
 	sig := primitives.Sign(priv, data)
 	fs := new(FactoidSignature)

--- a/common/factoid/signature_test.go
+++ b/common/factoid/signature_test.go
@@ -18,11 +18,13 @@ import (
 var _ = ed25519.Sign
 var _ = rand.New
 
+// Global signatures used for testing
 var sig1 [64]byte
 var sig2 [64]byte
 
 var s1, s2 interfaces.ISignature
 
+// TestUnmarshalNilFactoidSignature checks that unmarshalling nil and the empty interface result in proper errors
 func TestUnmarshalNilFactoidSignature(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -42,6 +44,7 @@ func TestUnmarshalNilFactoidSignature(t *testing.T) {
 	}
 }
 
+// TestSetup_Signature just sets up the global signatures (not a real test)
 func TestSetup_Signature(t *testing.T) {
 	sh11 := primitives.Sha([]byte("sig first half  one")).Bytes()
 	sh12 := primitives.Sha([]byte("sig second half one")).Bytes()
@@ -59,6 +62,7 @@ func TestSetup_Signature(t *testing.T) {
 	s2.SetSignature(sig2[:])
 }
 
+// TestNewED25519Signature checks that signatures can be set up in cononical form
 func TestNewED25519Signature(t *testing.T) {
 	testData := primitives.Sha([]byte("sig first half  one")).Bytes()
 	priv := testHelper.NewPrivKey(0)

--- a/common/factoid/signatureblock.go
+++ b/common/factoid/signatureblock.go
@@ -19,23 +19,25 @@ import (
  * how to apply the signatures to the addresses in the RCD.
  **************************************/
 
+// SignatureBlock is an object for holding multiple signatures
 type SignatureBlock struct {
-	Signatures []interfaces.ISignature `json:"signatures"`
+	Signatures []interfaces.ISignature `json:"signatures"` // Slice of signatures
 }
 
 var _ interfaces.ISignatureBlock = (*SignatureBlock)(nil)
 
-func (b *SignatureBlock) IsSameAs(s interfaces.ISignatureBlock) bool {
-	if s == nil {
-		return b == nil
+// IsSameAs returns true iff the input signature block contains the same signatures in the same ordering
+func (s *SignatureBlock) IsSameAs(si interfaces.ISignatureBlock) bool {
+	if si == nil {
+		return s == nil
 	}
 
-	sigs := s.GetSignatures()
-	if len(b.Signatures) != len(sigs) {
+	sigs := si.GetSignatures()
+	if len(s.Signatures) != len(sigs) {
 		return false
 	}
-	for i := range b.Signatures {
-		if b.Signatures[i].IsSameAs(sigs[i]) == false {
+	for i := range s.Signatures {
+		if s.Signatures[i].IsSameAs(sigs[i]) == false {
 			return false
 		}
 	}
@@ -43,27 +45,32 @@ func (b *SignatureBlock) IsSameAs(s interfaces.ISignatureBlock) bool {
 	return true
 }
 
-func (b SignatureBlock) UnmarshalBinary(data []byte) error {
-	_, err := b.UnmarshalBinaryData(data)
+// UnmarshalBinary unmarshals the input data into this object
+func (s SignatureBlock) UnmarshalBinary(data []byte) error {
+	_, err := s.UnmarshalBinaryData(data)
 	return err
 }
 
-func (e *SignatureBlock) JSONByte() ([]byte, error) {
-	return primitives.EncodeJSON(e)
+// JSONByte returns the json encoded byte array
+func (s *SignatureBlock) JSONByte() ([]byte, error) {
+	return primitives.EncodeJSON(s)
 }
 
-func (e *SignatureBlock) JSONString() (string, error) {
-	return primitives.EncodeJSONString(e)
+// JSONString returns the json encoded string
+func (s *SignatureBlock) JSONString() (string, error) {
+	return primitives.EncodeJSONString(s)
 }
 
-func (b SignatureBlock) String() string {
-	txt, err := b.CustomMarshalText()
+// String returns this object as a string
+func (s SignatureBlock) String() string {
+	txt, err := s.CustomMarshalText()
 	if err != nil {
 		return "<error>"
 	}
 	return string(txt)
 }
 
+// AddSignature appends the input signature to the existing signatures - FIX, is this how its supposed to work? always set to zeroth?
 func (s *SignatureBlock) AddSignature(sig interfaces.ISignature) {
 	if len(s.Signatures) > 0 {
 		s.Signatures[0] = sig
@@ -72,6 +79,7 @@ func (s *SignatureBlock) AddSignature(sig interfaces.ISignature) {
 	}
 }
 
+// GetSignature returns the signature at the input index
 func (s SignatureBlock) GetSignature(index int) interfaces.ISignature {
 	if len(s.Signatures) <= index {
 		return nil
@@ -79,6 +87,7 @@ func (s SignatureBlock) GetSignature(index int) interfaces.ISignature {
 	return s.Signatures[index]
 }
 
+// GetSignatures returns the signature slice
 func (s SignatureBlock) GetSignatures() []interfaces.ISignature {
 	if s.Signatures == nil {
 		s.Signatures = make([]interfaces.ISignature, 1, 1)
@@ -87,9 +96,10 @@ func (s SignatureBlock) GetSignatures() []interfaces.ISignature {
 	return s.Signatures
 }
 
-func (a SignatureBlock) MarshalBinary() ([]byte, error) {
+// MarshalBinary marshals this object
+func (s SignatureBlock) MarshalBinary() ([]byte, error) {
 	buf := primitives.NewBuffer(nil)
-	for _, sig := range a.GetSignatures() {
+	for _, sig := range s.GetSignatures() {
 		err := buf.PushBinaryMarshallable(sig)
 		if err != nil {
 			return nil, err
@@ -98,6 +108,7 @@ func (a SignatureBlock) MarshalBinary() ([]byte, error) {
 	return buf.DeepCopyBytes(), nil
 }
 
+// CustomMarshalText returns this object as a custom string
 func (s SignatureBlock) CustomMarshalText() ([]byte, error) {
 	var out primitives.Buffer
 
@@ -116,6 +127,7 @@ func (s SignatureBlock) CustomMarshalText() ([]byte, error) {
 	return out.DeepCopyBytes(), nil
 }
 
+// UnmarshalBinaryData unmarshals the input data into this object
 func (s *SignatureBlock) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	buf := primitives.NewBuffer(data)
 	s.Signatures = make([]interfaces.ISignature, 1)
@@ -127,6 +139,8 @@ func (s *SignatureBlock) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	return buf.DeepCopyBytes(), nil
 }
 
+// NewSingleSignatureBlock creates a new signature block with a single signature created from the
+// input private key and data
 func NewSingleSignatureBlock(priv, data []byte) *SignatureBlock {
 	s := new(SignatureBlock)
 	s.AddSignature(NewED25519Signature(priv, data))

--- a/common/factoid/signatureblock_test.go
+++ b/common/factoid/signatureblock_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
+// TestUnmarshalNilSignatureBlock checks that unmarshaling nil ore the empty interface results in proper errors
 func TestUnmarshalNilSignatureBlock(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -32,6 +33,8 @@ func TestUnmarshalNilSignatureBlock(t *testing.T) {
 	}
 }
 
+// TestSignatureBlock checks that a new single signature block can be created and its signature can be
+// used in a cononical form to sign data
 func TestSignatureBlock(t *testing.T) {
 	priv := testHelper.NewPrivKey(0)
 	testData, err := hex.DecodeString("00112233445566778899")

--- a/common/factoid/transaddress.go
+++ b/common/factoid/transaddress.go
@@ -20,15 +20,17 @@ import (
 	"github.com/FactomProject/factomd/common/primitives/random"
 )
 
+// TransAddress contains an address associated with a transaction and a transaction amount
 type TransAddress struct {
-	Amount  uint64              `json:"amount"`
-	Address interfaces.IAddress `json:"address"`
+	Amount  uint64              `json:"amount"`  // The amount in factoshis
+	Address interfaces.IAddress `json:"address"` // The address for this transaction
 	// Not marshalled
-	UserAddress string `json:"useraddress"`
+	UserAddress string `json:"useraddress"` // Human readable address for this transaction
 }
 
 var _ interfaces.ITransAddress = (*TransAddress)(nil)
 
+// RandomTransAddress returns a new random TransAddress with a random amount
 func RandomTransAddress() interfaces.ITransAddress {
 	ta := new(TransAddress)
 	ta.Address = RandomAddress()
@@ -37,43 +39,51 @@ func RandomTransAddress() interfaces.ITransAddress {
 	return ta
 }
 
-func (t *TransAddress) SetUserAddress(v string) {
-	t.UserAddress = v
+// SetUserAddress sets the user address to the input
+func (ta *TransAddress) SetUserAddress(v string) {
+	ta.UserAddress = v
 }
 
-func (t *TransAddress) GetUserAddress() string {
-	return t.UserAddress
+// GetUserAddress returns the user address
+func (ta *TransAddress) GetUserAddress() string {
+	return ta.UserAddress
 }
 
-func (t *TransAddress) UnmarshalBinary(data []byte) error {
-	_, err := t.UnmarshalBinaryData(data)
+// UnmarshalBinary unmarshals the input data into this object
+func (ta *TransAddress) UnmarshalBinary(data []byte) error {
+	_, err := ta.UnmarshalBinaryData(data)
 	return err
 }
 
-func (e *TransAddress) JSONByte() ([]byte, error) {
-	return primitives.EncodeJSON(e)
+// JSONByte returns the json encoded byte array
+func (ta *TransAddress) JSONByte() ([]byte, error) {
+	return primitives.EncodeJSON(ta)
 }
 
-func (e *TransAddress) JSONString() (string, error) {
-	return primitives.EncodeJSONString(e)
+// JSONString returns the json encoded string
+func (ta *TransAddress) JSONString() (string, error) {
+	return primitives.EncodeJSONString(ta)
 }
 
-func (t *TransAddress) String() string {
-	str, _ := t.JSONString()
+// String returns this object as a string
+func (ta *TransAddress) String() string {
+	str, _ := ta.JSONString()
 	return str
 }
 
-func (t *TransAddress) IsSameAs(add interfaces.ITransAddress) bool {
-	if t.GetAmount() != add.GetAmount() {
+// IsSameAs returns true iff the input object is identical to this object
+func (ta *TransAddress) IsSameAs(add interfaces.ITransAddress) bool {
+	if ta.GetAmount() != add.GetAmount() {
 		return false
 	}
-	if t.GetAddress().IsSameAs(add.GetAddress()) == false {
+	if ta.GetAddress().IsSameAs(add.GetAddress()) == false {
 		return false
 	}
 	return true
 }
 
-func (t *TransAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
+// UnmarshalBinaryData unmrashals the input data into this object
+func (ta *TransAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	//
 	if len(data) < 33 { // leading varint has to be one or more bytes and the address is 32
 		return nil, fmt.Errorf("Data source too short in TransAddress.UnmarshalBinaryData() an address: %d", len(data))
@@ -81,7 +91,7 @@ func (t *TransAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	buf := primitives.NewBuffer(data)
 	var err error
 
-	t.Amount, err = buf.PopVarInt()
+	ta.Amount, err = buf.PopVarInt()
 	if len(data) < 32 { // after the varint there have to be 32 bytes left but there may be some other struct following so longer is fine
 		return nil, fmt.Errorf("Data source too short in TransAddress.UnmarshalBinaryData() an address: %d", len(data))
 	}
@@ -89,8 +99,8 @@ func (t *TransAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	t.Address = new(Address)
-	err = buf.PopBinaryMarshallable(t.Address)
+	ta.Address = new(Address)
+	err = buf.PopBinaryMarshallable(ta.Address)
 	if err != nil {
 		return nil, err
 	}
@@ -98,50 +108,52 @@ func (t *TransAddress) UnmarshalBinaryData(data []byte) ([]byte, error) {
 	return buf.DeepCopyBytes(), nil
 }
 
-// MarshalBinary.  'nuff said
-func (a TransAddress) MarshalBinary() ([]byte, error) {
+// MarshalBinary marshals the object
+func (ta TransAddress) MarshalBinary() ([]byte, error) {
 	buf := primitives.NewBuffer(nil)
-	err := buf.PushVarInt(a.Amount)
+	err := buf.PushVarInt(ta.Amount)
 	if err != nil {
 		return nil, err
 	}
-	err = buf.PushBinaryMarshallable(a.Address)
+	err = buf.PushBinaryMarshallable(ta.Address)
 	if err != nil {
 		return nil, err
 	}
 	return buf.DeepCopyBytes(), nil
 }
 
-// Accessor. Default to a zero length string.  This is a debug
+// GetName defaults to a zero length string.  This is a debug
 // thing for looking out what we have built. Used by
 // CustomMarshalText
 func (ta TransAddress) GetName() string {
 	return ""
 }
 
-// Accessor.  Get the amount with this address.
+// GetAmount returns the transaction amount in factoshis for this address.
 func (ta TransAddress) GetAmount() uint64 {
 	return ta.Amount
 }
 
-// Accessor.  Get the amount with this address.
+// SetAmount sets the transaction amount in factoshis for this address.
 func (ta *TransAddress) SetAmount(amount uint64) {
 	ta.Amount = amount
 }
 
-// Accessor.  Get the raw address.  Could be an actual address,
+// GetAddress gets the raw address.  Could be an actual address,
 // or a hash of an authorization block.  See authorization.go
 func (ta TransAddress) GetAddress() interfaces.IAddress {
 	return ta.Address
 }
 
-// Accessor.  Get the raw address.  Could be an actual address,
+// SetAddress sets the raw address.  Could be an actual address,
 // or a hash of an authorization block.  See authorization.go
 func (ta *TransAddress) SetAddress(address interfaces.IAddress) {
 	ta.Address = address
 }
 
-// Make this into somewhat readable text.
+// CustomMarshalTextAll marshals the object into somewhat readable text. Input 'fct' bool tells the function
+// whether to interpret the address as an FCT address or an EC address. Input string 'label' is a user
+// defined debug string to help differentiate other TransAddress in string form
 func (ta TransAddress) CustomMarshalTextAll(fct bool, label string) ([]byte, error) {
 	var out primitives.Buffer
 	out.WriteString(fmt.Sprintf("   %8s:", label))
@@ -159,36 +171,44 @@ func (ta TransAddress) CustomMarshalTextAll(fct bool, label string) ([]byte, err
 	return out.DeepCopyBytes(), nil
 }
 
+// CustomMarshalText2 marshals the object as an FCT address with the input label
 func (ta TransAddress) CustomMarshalText2(label string) ([]byte, error) {
 	return ta.CustomMarshalTextAll(true, label)
 }
 
+// CustomMarshalTextEC2 marshals this object as an EC address with the input label
 func (ta TransAddress) CustomMarshalTextEC2(label string) ([]byte, error) {
 	return ta.CustomMarshalTextAll(false, label)
 }
 
+// CustomMarshalTextInput marshals the object as an FCT address with label 'input'
 func (ta TransAddress) CustomMarshalTextInput() ([]byte, error) {
 	return ta.CustomMarshalText2("input")
 }
 
+// StringInput marshals the object to a string as an FCT address with label 'input'
 func (ta TransAddress) StringInput() string {
 	b, _ := ta.CustomMarshalTextInput()
 	return string(b)
 }
 
+// CustomMarshalTextOutput marshals the object to a string as an FCT address with label 'output'
 func (ta TransAddress) CustomMarshalTextOutput() ([]byte, error) {
 	return ta.CustomMarshalText2("output")
 }
 
+// StringOutput marshals the object to a string as an FCT address with label 'output'
 func (ta TransAddress) StringOutput() string {
 	b, _ := ta.CustomMarshalTextOutput()
 	return string(b)
 }
 
+// CustomMarshalTextECOutput marshals this object as an EC address with label 'ecoutput'
 func (ta TransAddress) CustomMarshalTextECOutput() ([]byte, error) {
 	return ta.CustomMarshalTextEC2("ecoutput")
 }
 
+// StringECOutput marshals the object to a string as an EC address with label 'ecoutput'
 func (ta TransAddress) StringECOutput() string {
 	b, _ := ta.CustomMarshalTextECOutput()
 	return string(b)
@@ -198,6 +218,7 @@ func (ta TransAddress) StringECOutput() string {
  * Helper functions
  ******************************/
 
+// NewOutECAddress creates a new TransAddress with input EC address and amount
 func NewOutECAddress(address interfaces.IAddress, amount uint64) interfaces.ITransAddress {
 	ta := new(TransAddress)
 	ta.Amount = amount
@@ -206,6 +227,7 @@ func NewOutECAddress(address interfaces.IAddress, amount uint64) interfaces.ITra
 	return ta
 }
 
+// NewOutAddress creates a new TransAddress with input FCT address and amount
 func NewOutAddress(address interfaces.IAddress, amount uint64) interfaces.ITransAddress {
 	ta := new(TransAddress)
 	ta.Amount = amount
@@ -214,6 +236,7 @@ func NewOutAddress(address interfaces.IAddress, amount uint64) interfaces.ITrans
 	return ta
 }
 
+// NewInAddress creates a new TransAddress with input FCT address and amount
 func NewInAddress(address interfaces.IAddress, amount uint64) interfaces.ITransAddress {
 	ta := new(TransAddress)
 	ta.Amount = amount

--- a/common/factoid/transaddress_test.go
+++ b/common/factoid/transaddress_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
+// TestUnmarshalNilTransAddress checks that unmarshalling nil or the empty interface returns proper errors
 func TestUnmarshalNilTransAddress(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -36,6 +37,8 @@ func TestUnmarshalNilTransAddress(t *testing.T) {
 	}
 }
 
+// TestTAddressEquals creates 1000 random trans addresses does various manipulations to check that they are equal when they should be
+// and not equal when different. Also checks for integrity of marshal and unmarshal
 func TestTAddressEquals(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		a1 := RandomTransAddress()
@@ -81,6 +84,7 @@ func TestTAddressEquals(t *testing.T) {
 	}
 }
 
+// TestTransMarshalUnmarshal checks that trans address can be marshalled and unmarshalled correctly
 func TestTransAddressMarshalUnmarshal(t *testing.T) {
 	ta := new(TransAddress)
 	ta.SetAmount(12345678)
@@ -113,6 +117,7 @@ func TestTransAddressMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// TestOutECAddress checks that NewOutECAddress returns the proper object
 func TestOutECAddress(t *testing.T) {
 	h, err := primitives.HexToHash("ec9f1cefa00406b80d46135a53504f1f4182d4c0f3fed6cca9281bc020eff973")
 	if err != nil {
@@ -141,6 +146,7 @@ func TestOutECAddress(t *testing.T) {
 	}
 }
 
+// TestOutAddress checks that NewOutAddress returns the proper object
 func TestOutAddress(t *testing.T) {
 	h, err := primitives.HexToHash("ec9f1cefa00406b80d46135a53504f1f4182d4c0f3fed6cca9281bc020eff973")
 	if err != nil {
@@ -169,6 +175,7 @@ func TestOutAddress(t *testing.T) {
 	}
 }
 
+// TestInAddress checks that NewInAddress returns the proper object
 func TestInAddress(t *testing.T) {
 	h, err := primitives.HexToHash("ec9f1cefa00406b80d46135a53504f1f4182d4c0f3fed6cca9281bc020eff973")
 	if err != nil {
@@ -197,7 +204,7 @@ func TestInAddress(t *testing.T) {
 	}
 }
 
-// Test multiple trans addresses in the same binary blob
+// TestTransAddressBlob tests multiple trans addresses in the same binary blob
 func TestTransAddressBlob(t *testing.T) {
 	var err error
 	// TODO: Add unit test to cover unmarshaling multiple transaddresses from same binary blob
@@ -235,6 +242,7 @@ func TestTransAddressBlob(t *testing.T) {
 	}
 }
 
+// TestVectorTransAddressMarshalling checks trans addresses can be marshalled and unmarshalled properly
 func TestVectorTransAddressMarshalling(t *testing.T) {
 	amounts := []uint64{
 		0, 1, 2, 3, 4, 5, 100, 1000, 1e10, math.MaxUint32, math.MaxUint64 - 1, math.MaxUint64,
@@ -252,6 +260,7 @@ func TestVectorTransAddressMarshalling(t *testing.T) {
 
 }
 
+// TestRandomTransAddressMarshalling checks that 100 random trans addresses can be marshalled and unmarshalled properly
 func TestRandomTransAddressMarshalling(t *testing.T) {
 	// Test Random addresses with random amounts
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Variety of changes. Lots of comments, receiver changes, minor refactors, some additions to unit tests. Two changes to pay attention to, are the runstates.go where some real code changes were made. And to rcd1.go where a new unit test was created. It grabs a transaction, the rcd, and its signature. Then corrupts the signature and tries to verify the RCD fails (which it does with current code), then tries to verify with the proper signature to make sure it passes (which it does with current code), and then tries to verify the RCD again with a corrupted signature to make sure it fails (which it does with current code). This test passes with current code. My changes fix a problem in the RCD1 caching mechanism where it was not caching the verification correctly. Not it caches it correctly, however, this causes the unit test i just created to now FAIL, because the second RCD check with the corrupted signature comes AFTER a 'good' check which sets the cache to be true, and so any verification after will be reported as true. I was told that this wouldn't be an issue because in the code you can't use the RCD to verify on a different signature. But just look over this section carefully.