### PR TITLE
Hotfix for diagnostics index out of range error

### DIFF
--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -1585,7 +1585,16 @@ func HandleV2Diagnostics(state interfaces.IState, params interface{}) (interface
 			eInfo.VmIndex = &vm
 			eInfo.FedIndex = &electing
 			eInfo.FedID = e.GetFedID().String()
-			eInfo.Round = &e.GetRound()[electing]
+			// bugfix for https://github.com/FactomProject/factomd/issues/947
+			// the round slice is frequently truncated to zero-length and the default
+			// behavior is to zero-pad it on demand
+			round := e.GetRound()
+			if electing < len(round) {
+				eInfo.Round = &round[electing]
+			} else {
+				zero := 0 // backward compatibility for any consumer that relied on this being present
+				eInfo.Round = &zero
+			}
 		}
 	}
 	resp.ElectionInfo = eInfo


### PR DESCRIPTION
closes: #947 

The elections.Elections struct isn't thread safe, which has caused multiple node crashes for the API "diagnostics" call. It first retrieves the index of the server being elected, then several lines later tries to retrieve the "rounds" count for that server. The "rounds" slice is reset whenever an election is finished and then zero-padded on demand. There are likely two edge cases that can cause a crash:
1. An election finishes right after the index is retrieved, truncating "rounds" to a zero-length slice
2. A new election is started but the "rounds" array hasn't been zero-padded yet

The proper fix would be to create a snapshot of the current "Elections" state via a deep copy to use for the diagnostics call, or provide thread-safe accessor functions for the relevant data, one of which should be done at some point the future.

This fix just makes a copy of the slice and only accesses it if the index is present, using 0 otherwise. For edge case 1., this would result in the loss of the round counter for that call.