### PR TITLE
Handle API panics more gracefully

### DIFF
--- a/wsapi/server.go
+++ b/wsapi/server.go
@@ -113,9 +113,9 @@ func PanicRecovery() Middleware {
 	return func(f http.HandlerFunc) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
-				if r := recover(); r != nil {
+				if rec := recover(); r != nil {
 					trace := debug.Stack()
-					wsLog.Errorf("Recovered from a panic: %v: %s", r, string(trace))
+					wsLog.Errorf("Recovered from a panic: %v: %s", rec, string(trace))
 					HandleV2Error(w, nil, NewInternalError())
 				}
 			}()

--- a/wsapi/server.go
+++ b/wsapi/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strconv"
 	"time"
 
@@ -108,10 +109,26 @@ func IDInjector(server *Server) Middleware {
 	}
 }
 
+func PanicRecovery() Middleware {
+	return func(f http.HandlerFunc) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if r := recover(); r != nil {
+					trace := debug.Stack()
+					wsLog.Errorf("Recovered from a panic: %v: %s", r, string(trace))
+					HandleV2Error(w, nil, NewInternalError())
+				}
+			}()
+			f(w, r)
+		}
+	}
+}
+
 // add route and Chain applies middlewares to a http.HandlerFunc
 func (server *Server) addRoute(path string, f func(http.ResponseWriter, *http.Request), middlewares ...Middleware) *mux.Route {
 	middlewares = append(middlewares, APILogger())
 	middlewares = append(middlewares, IDInjector(server))
+	middlewares = append(middlewares, PanicRecovery()) // keep this last
 	for _, m := range middlewares {
 		f = m(f)
 	}


### PR DESCRIPTION
The golang server is able to handle panics inside of an http request without crashing* but at the moment, panics in are not handled gracefully. It a) prints the stacktrace to stderr, b) sends no output to the client. 

This change adds a panic recovery middleware that addresses both of these.
* If recovering from a panic, write the error to the API log file via `wsLog` like other API errors
* Return an "Internal Error" to the client

\* unless the goroutine causes another goroutine to crash due to multithreading issues or the panic is not recoverable