### PR TITLE
Fd 1225 sync pubthreaded calls

### DIFF
--- a/longTest/LeaderModule_test.go
+++ b/longTest/LeaderModule_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"github.com/FactomProject/factom"
 	"github.com/FactomProject/factomd/fnode"
+	"github.com/FactomProject/factomd/state"
 	. "github.com/FactomProject/factomd/testHelper"
 	"testing"
 )
 
 //  Currently just tests FCT/EC Commit/Reveal messages to make sure leader is working
 func TestLeaderModule(t *testing.T) {
+	state.EnableLeaderThread = true // enable threaded leader behavior for this test
 
 	encode := func(s string) []byte {
 		b := bytes.Buffer{}

--- a/modules/leader/thread.go
+++ b/modules/leader/thread.go
@@ -29,12 +29,15 @@ func (p *Pub) Init(nodeName string) {
 	go p.MsgOut.Start()
 }
 
+type role = int
+
 const (
-	LEADER_ROLE = iota + 1
-	FOLLOWER_ROLE
+	FederatedRole role = iota + 1
+	AuditRole
+	FollowerRole
 )
 
-type role = int
+var _ = AuditRole // REVIEW: if Audit responsibilities are different from normal Fed then use this
 
 type Sub struct {
 	role
@@ -71,10 +74,10 @@ func (s *Sub) Start(nodeName string) {
 
 // start listening to subscriptions for leader duties
 func (s *Sub) SetLeaderMode(nodeName string) {
-	if s.role == LEADER_ROLE {
+	if s.role == FederatedRole {
 		return
 	}
-	s.role = LEADER_ROLE
+	s.role = FederatedRole
 	s.MsgInput.Subscribe(pubsub.GetPath(nodeName, "bmv", "rest"))
 	s.MovedToHeight.Subscribe(pubsub.GetPath(nodeName, event.Path.Seq))
 	s.DBlockCreated.Subscribe(pubsub.GetPath(nodeName, event.Path.Directory))
@@ -83,10 +86,10 @@ func (s *Sub) SetLeaderMode(nodeName string) {
 
 // stop subscribers that we do not need as a follower
 func (s *Sub) SetFollowerMode() {
-	if s.role == FOLLOWER_ROLE {
+	if s.role == FollowerRole {
 		return
 	}
-	s.role = FOLLOWER_ROLE
+	s.role = FollowerRole
 	s.MsgInput.Unsubscribe()
 	s.MovedToHeight.Unsubscribe()
 	s.BalanceChanged.Unsubscribe()

--- a/pubsub/examples/unsubscribe/main.go
+++ b/pubsub/examples/unsubscribe/main.go
@@ -1,0 +1,99 @@
+// This
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/FactomProject/factomd/common/messages"
+	. "github.com/FactomProject/factomd/pubsub"
+)
+
+func logf(f string, a ...interface{}) {
+	f = f + "\n"
+	fmt.Printf(f, a...)
+}
+
+func main() {
+	ResetGlobalRegistry()
+	nodeName := "FNode0"
+
+	type Module struct {
+		Path   string
+		MsgOut IPublisher
+		MsgIn  *SubChannel
+		Count  int
+	}
+
+	p := &Module{Path: GetPath(nodeName, "test")}
+	p.MsgOut = PubFactory.Threaded(1).Publish(p.Path)
+	go p.MsgOut.Start()
+
+	p.MsgIn = SubFactory.Channel(1)
+	p.MsgIn.Subscribe(GetPath(nodeName, "test"))
+
+	exit := make(chan interface{})
+
+	go func() { // Reader
+		timeOut := time.After(1 * time.Second)
+
+		for {
+			select {
+			case <-timeOut:
+				logf("Successfully unsubscribed")
+				if p.Count != 5 {
+					logf("Unexpected number of messages from subscriber %v", p.Count)
+				}
+				close(exit)
+				return
+			case v := <-p.MsgIn.Updates:
+				m := v.(messages.Bounce)
+				p.Count += 1
+				logf("%v: %v - %v", p.Count, m.Name, m.Number)
+
+				if m.Number < 0 {
+					// have subscriber disconnect himself
+					p.MsgIn.Unsubscribe()
+					logf("%v: unsubscribed len: %v", p.Count, len(p.MsgIn.Updates))
+				}
+
+				if p.Count > 10 {
+					logf("Failed to unsubscribe")
+					close(exit)
+					return
+
+				}
+			}
+		}
+	}()
+
+	go func() { // writer
+		var i int32 = 0
+		m := messages.Bounce{Name: "Test"}
+
+		for {
+			select {
+			case <-exit:
+				return
+			default:
+				i += 1
+				if i == 5 {
+					m.Number = -1 // signal client you are bout to disconnect
+				} else {
+					m.Number = i
+				}
+
+				p.MsgOut.Write(m)
+
+				if m.Number < 0 {
+					p.MsgOut.Unsubscribe(p.MsgIn) // unsubscribe from this end
+				}
+
+				time.Sleep(time.Millisecond * 50)
+			}
+		}
+	}()
+
+	<-exit
+}

--- a/pubsub/pBase.go
+++ b/pubsub/pBase.go
@@ -63,11 +63,9 @@ func (p *PubBase) Subscribe(subscriber IPubSubscriber) bool {
 }
 
 func (p *PubBase) Write(o interface{}) {
-	p.RLock()
 	for i := range p.Subscribers {
 		p.Subscribers[i].write(o)
 	}
-	p.RUnlock()
 }
 
 func (PubBase) Start() {

--- a/pubsub/pThreaded.go
+++ b/pubsub/pThreaded.go
@@ -41,10 +41,6 @@ func (p *PubThreaded) Close() error {
 	return nil
 }
 
-func (p *PubThreaded) WriteWithCallback(o interface{}, callback ...func()) {
-	p.inputs <- o
-}
-
 func (p *PubThreaded) Write(o interface{}) {
 	p.inputs <- o
 }
@@ -136,6 +132,7 @@ func (p *PubThreaded) CountSubscriberSync(replyChannel ...chan interface{}) {
 	}
 }
 
+// optional reply channl allow waiting on async calls to unsubscribe
 func (p *PubThreaded) UnsubscribeSync(subscriber IPubSubscriber, replyChannel ...chan interface{}) bool {
 
 	var reply chan interface{}
@@ -153,6 +150,7 @@ func (p *PubThreaded) UnsubscribeSync(subscriber IPubSubscriber, replyChannel ..
 	return true
 }
 
+// optional reply channl allow waiting on async calls to subscribe
 func (p *PubThreaded) SubscribeSync(subscriber IPubSubscriber, replyChannel ...chan interface{}) bool {
 	var reply chan interface{}
 

--- a/pubsub/pThreaded.go
+++ b/pubsub/pThreaded.go
@@ -50,12 +50,7 @@ func (p *PubThreaded) Write(o interface{}) {
 }
 
 func (p *PubThreaded) Unsubscribe(subscriber IPubSubscriber) bool {
-	// Send the command to unsub
-	p.subChanges <- subAction{
-		Subscriber: subscriber,
-		Action:     UNSUBSCRIBE,
-	}
-	return true
+	return p.UnsubscribeSync(subscriber)
 }
 
 func (p *PubThreaded) unsubscribe(subscriber IPubSubscriber) (ok bool) {
@@ -72,12 +67,7 @@ func (p *PubThreaded) unsubscribe(subscriber IPubSubscriber) (ok bool) {
 }
 
 func (p *PubThreaded) Subscribe(subscriber IPubSubscriber) bool {
-	// Send the command to sub
-	p.subChanges <- subAction{
-		Subscriber: subscriber,
-		Action:     SUBSCRIBE,
-	}
-	return true
+	return p.SubscribeSync(subscriber)
 }
 
 func (p *PubThreaded) subscribe(subscriber IPubSubscriber) bool {

--- a/pubsub/pThreaded_test.go
+++ b/pubsub/pThreaded_test.go
@@ -1,0 +1,71 @@
+package pubsub_test
+
+import (
+	"github.com/FactomProject/factomd/common/messages"
+	. "github.com/FactomProject/factomd/pubsub"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSubUnSub(t *testing.T) {
+	ResetGlobalRegistry()
+	nodeName := "FNode0"
+
+	type Module struct {
+		Path   string
+		MsgOut IPublisher
+		MsgIn0 *SubChannel
+		MsgIn1 *SubChannel
+	}
+
+	p := &Module{Path: GetPath(nodeName, "test")}
+	p.MsgOut = PubFactory.Threaded(10).Publish(p.Path)
+	pub := p.MsgOut.(*PubThreaded)
+	go pub.Start()
+
+	p.MsgIn0 = SubFactory.Channel(10)
+	p.MsgIn0.Subscribe(GetPath(nodeName, "test"))
+
+	p.MsgIn1 = SubFactory.Channel(10)
+	p.MsgIn1.Subscribe(GetPath(nodeName, "test"))
+
+	replyChannel := make(chan interface{}, 10)
+
+	getCount := func() {
+		pub.CountSubscriberSync(replyChannel)
+		for {
+			select {
+			case v := <-replyChannel:
+				t.Logf("got count %v", v)
+				if v.(int) == 2 {
+					return
+				}
+			}
+		}
+	}
+	getCount()
+
+	// Write to both
+	p.MsgOut.Write(messages.Bounce{Name: "foo"})
+
+	<-p.MsgIn0.Updates
+	assert.Len(t, p.MsgIn1.Updates, 1)
+	<-p.MsgIn1.Updates
+
+	// Unsubscribe
+	pub.UnsubscribeSync(p.MsgIn1, replyChannel)
+	v := <-replyChannel
+	//t.Logf("UnsubscribeSync: %v\n", v)
+
+	// Should only write to one queue
+	p.MsgOut.Write(messages.Bounce{Name: "bar"})
+	<-p.MsgIn0.Updates
+	assert.Len(t, p.MsgIn1.Updates, 0)
+
+	// resubscribe
+	pub.SubscribeSync(p.MsgIn1, replyChannel)
+	v = <-replyChannel
+	//t.Logf("ResubscribeSync: %v\n", v)
+	assert.Equal(t, 2, v.(int))
+
+}

--- a/pubsub/swMsgFilter_test.go
+++ b/pubsub/swMsgFilter_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/FactomProject/factomd/common/messages"
 	. "github.com/FactomProject/factomd/pubsub"
 	"testing"
-	"time"
 )
 
 func TestSubMsgFilterWrap(t *testing.T) {
@@ -32,94 +31,4 @@ func TestSubMsgFilterWrap(t *testing.T) {
 			t.Error("type is wrong")
 		}
 	}
-}
-
-func TestSubUnSub(t *testing.T) {
-	ResetGlobalRegistry()
-	nodeName := "FNode0"
-
-	type Module struct {
-		Path   string
-		MsgOut IPublisher
-		MsgIn  *SubChannel
-		Count  int
-	}
-
-	p := &Module{Path: GetPath(nodeName, "test")}
-	p.MsgOut = PubFactory.Threaded(1).Publish(p.Path)
-	go p.MsgOut.Start()
-
-	p.MsgIn = SubFactory.Channel(1)
-	p.MsgIn.Subscribe(GetPath(nodeName, "test"))
-
-	exit := make(chan interface{})
-
-	drain := func() { // purge channel
-		for {
-			select {
-			case <-p.MsgIn.Updates:
-				// drain
-			default:
-				return
-			}
-		}
-	}
-	_ = drain
-
-	go func() { // Reader
-		timeOut := time.After(1 * time.Second)
-
-		for {
-			select {
-			case <-timeOut:
-				t.Log("Successfully unsubscribed")
-				if p.Count != 5 {
-					t.Errorf("Unexpected number of messages from subscriber %v", p.Count)
-				}
-				//  pass
-				close(exit)
-				return
-			case v := <-p.MsgIn.Updates:
-				m := v.(messages.Bounce)
-				p.Count += 1
-				t.Logf("%v: %v - %v", p.Count, m.Name, m.Number)
-
-				if m.Number < 0 {
-					p.MsgIn.Unsubscribe()
-					t.Logf("%v: unsubscribed len: %v", p.Count, len(p.MsgIn.Updates))
-					//drain() // purge remaining updates
-				}
-
-				if p.Count > 10 {
-					t.Errorf("Failed to unsubscribe")
-					close(exit)
-					return
-
-				}
-			}
-		}
-	}()
-
-	go func() { // writer
-		var i int32 = 0
-		m := messages.Bounce{Name: "Test"}
-
-		for {
-			select {
-			case <-exit:
-				return
-			default:
-				i += 1
-				if i == 5 {
-					m.Number = -1 // send disconnect
-				} else {
-					m.Number = i
-				}
-				p.MsgOut.Write(m)
-				time.Sleep(time.Millisecond * 50)
-			}
-		}
-	}()
-
-	<-exit
 }


### PR DESCRIPTION
Added methods for interacting with threaded publisher 
to avoid data race in testing

Did not update the Interfaces - unsure if we want to use this style of interaction during the 'standard' usage of the pubsub package.