### PR TITLE
Ident Hash crash fix

### DIFF
--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -103,12 +103,20 @@ func (p *Peer) AddressPort() string {
 }
 
 func (p *Peer) PeerIdent() string {
-	return p.Hash[0:12] + "-" + p.Address + ":" + p.Port
+	h := p.Hash
+	if len(h) > 12 {
+		h = h[:12]
+	}
+	return h + "-" + p.Address + ":" + p.Port
 }
 
 func (p *Peer) PeerFixedIdent() string {
+	h := p.Hash
+	if len(h) > 12 {
+		h = h[:12]
+	}
 	address := fmt.Sprintf("%16s", p.Address)
-	return p.Hash[0:12] + "-" + address + ":" + p.Port
+	return h + "-" + address + ":" + p.Port
 }
 
 func (p *Peer) PeerLogFields() log.Fields {


### PR DESCRIPTION
This is an error reported by [Consensus Networks]nate on discord, running 6.5.1-rc2 on the testnet: https://gist.github.com/natemiller1/4097a0cd5624e5ce256e14b94f8bec2e

In the old p2p code, a shared peer's hash isn't verified so any input is accepted into the system. If the hash happens to be too short, for example the ip address `1.20.30.40`, PeerIdent() and PeerFixedIdent() try to access a range that's too long. It only happens if there is a real node it can connect to behind the ip address and tries to update the quality score.

The reason the node crashed is because PeerFixedIdent() is called inside the recovery defer. With this fix this issue is addressed and all future errors of this type (if they exist) should be recovered from without a crash.