### PR TITLE
Add client-side port specification option

### DIFF
--- a/common/globals/globals.go
+++ b/common/globals/globals.go
@@ -88,6 +88,7 @@ type FactomParams struct {
 	EventReceiverProtocol    string
 	EventReceiverHost        string
 	EventReceiverPort        int
+	EventSenderPort          int
 	EventFormat              string
 	EventSendStateChange     bool
 	EventBroadcastContent    string

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -99,6 +99,7 @@ func init() {
 	flag.StringVar(&p.EventReceiverProtocol, "eventreceiverprotocol", "", "Transport protocol for the events receiver; default udp")
 	flag.StringVar(&p.EventReceiverHost, "eventreceiverhost", "", "Host address for the events receiver; default 127.0.0.1")
 	flag.IntVar(&p.EventReceiverPort, "eventreceiverport", 0, "Port for the events receiver; default 8040")
+	flag.IntVar(&p.EventSenderPort, "eventsenderport", 0, "Port for the events sender (client)")
 	flag.StringVar(&p.EventFormat, "eventformat", "", "Event output format for the events receiver, protobuf|json; default protobuf")
 	flag.BoolVar(&p.EventSendStateChange, "eventsendstatechange", false, "Send only StateChange events when the state of an entity changes instead of the full entity; default false")
 	flag.StringVar(&p.EventBroadcastContent, "eventbroadcastcontent", "", "Settings for including content in the event messages always|once|never; default once")

--- a/events/README.md
+++ b/events/README.md
@@ -18,6 +18,7 @@ EnableLiveFeedAPI                     = true
 EventReceiverProtocol                 = tcp
 EventReceiverHost                     = 127.0.0.1
 EventReceiverPort                     = 8040
+EventSenderPort                       = 8041
 EventFormat                           = protobuf
 EventSendStateChange                  = false
 EventBroadcastContent                 = OnRegistration 
@@ -32,6 +33,7 @@ Here is an overview of these options:
 |  EventReceiverProtocol            | The network protocol that is used to send event messages over the network.     | tcp &#124; udp |
 |  EventReceiverHost                | The receiver endpoint host.                                                | DNS name &#124; IP address |
 |  EventReceiverPort                | The receiver endpoint port.                                                  | port number |
+|  EventSenderPort                  | The client or sender port.                                                   | port number |
 |  EventFormat                      | The output format in which the event sent.                                      | protobuf &#124; json |
 |  EventSendStateChange             | It’s possible to choose whether the chain and entry commit registrations should only be sent once, followed by state change events vs resending them for every state change. The first option reduces overhead & network traffic, but requires the implementer to track which state changes belong to which chain or entry.| true &#124; false |
 |  EventBroadcastContent            | This option will determine whether the external ID’s and content will be included in the event stream. There are three level settings for this. Please note that the combination of EventSendStateChange = false and EventBroadcastContent=always, will resend all data on every state change. The maximum content size per entry is only 10KB, however with a large number of transactions per second this may add up to an undesirable amount of data. | always &#124; once &#124; never |

--- a/events/eventservices/eventServiceParameters.go
+++ b/events/eventservices/eventServiceParameters.go
@@ -2,6 +2,7 @@ package eventservices
 
 import (
 	"fmt"
+
 	"github.com/FactomProject/factomd/common/globals"
 	"github.com/FactomProject/factomd/events/eventconfig"
 	"github.com/FactomProject/factomd/log"
@@ -12,6 +13,7 @@ type EventServiceParams struct {
 	EnableLiveFeedAPI     bool
 	Protocol              string
 	Address               string
+	ClientPort            string
 	OutputFormat          eventconfig.EventFormat
 	ReplayDuringStartup   bool
 	SendStateChangeEvents bool
@@ -33,6 +35,11 @@ func selectParameters(factomParams *globals.FactomParams, config *util.FactomdCo
 		params.Address = fmt.Sprintf("%s:%d", config.LiveFeedAPI.EventReceiverHost, config.LiveFeedAPI.EventReceiverPort)
 	} else {
 		params.Address = fmt.Sprintf("%s:%d", defaultConnectionHost, defaultConnectionPort)
+	}
+	if factomParams != nil && factomParams.EventSenderPort > 0 {
+		params.ClientPort = fmt.Sprintf(":%d", factomParams.EventSenderPort)
+	} else if config != nil && config.LiveFeedAPI.EventSenderPort > 0 {
+		params.ClientPort = fmt.Sprintf(":%d", config.LiveFeedAPI.EventSenderPort)
 	}
 	if factomParams != nil && len(factomParams.EventFormat) > 0 {
 		params.OutputFormat = eventconfig.EventFormatFrom(factomParams.EventFormat, defaultOutputFormat)

--- a/events/eventservices/eventServiceParameters_test.go
+++ b/events/eventservices/eventServiceParameters_test.go
@@ -2,11 +2,12 @@ package eventservices
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/FactomProject/factomd/common/globals"
 	"github.com/FactomProject/factomd/events/eventconfig"
 	"github.com/FactomProject/factomd/util"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEventServiceParameters_DefaultParameters(t *testing.T) {
@@ -41,6 +42,7 @@ func TestEventServiceParameters_OverrideParameters(t *testing.T) {
 		EventReceiverProtocol:    "udp",
 		EventReceiverHost:        "0.0.0.0",
 		EventReceiverPort:        8888,
+		EventSenderPort:          8889,
 		EventFormat:              "json",
 		EventReplayDuringStartup: true,
 		EventSendStateChange:     true,
@@ -121,6 +123,7 @@ func buildBaseConfig(enable bool, protocol string, address string, port int, for
 			EventReceiverProtocol    string
 			EventReceiverHost        string
 			EventReceiverPort        int
+			EventSenderPort          int
 			EventFormat              string
 			EventReplayDuringStartup bool
 			EventSendStateChange     bool
@@ -130,6 +133,7 @@ func buildBaseConfig(enable bool, protocol string, address string, port int, for
 			EventReceiverProtocol:    protocol,
 			EventReceiverHost:        address,
 			EventReceiverPort:        port,
+			EventSenderPort:          port,
 			EventFormat:              format,
 			EventReplayDuringStartup: replay,
 			EventSendStateChange:     stateChange,

--- a/util/config.go
+++ b/util/config.go
@@ -112,6 +112,7 @@ type FactomdConfig struct {
 		EventReceiverProtocol    string
 		EventReceiverHost        string
 		EventReceiverPort        int
+		EventSenderPort          int
 		EventFormat              string
 		EventReplayDuringStartup bool
 		EventSendStateChange     bool
@@ -245,6 +246,7 @@ EnableLiveFeedAPI                     = false
 EventReceiverProtocol                 = tcp
 EventReceiverHost                     = 127.0.0.1
 EventReceiverPort                     = 8040
+EventSenderPort                       = 8040
 EventFormat                           = protobuf
 EventReplayDuringStartup              = false
 EventSendStateChange                  = false
@@ -322,6 +324,7 @@ func (s *FactomdConfig) String() string {
 	out.WriteString(fmt.Sprintf("\n    EventReceiverProtocol    %v", s.LiveFeedAPI.EventReceiverProtocol))
 	out.WriteString(fmt.Sprintf("\n    EventReceiverHost        %v", s.LiveFeedAPI.EventReceiverHost))
 	out.WriteString(fmt.Sprintf("\n    EventReceiverPort        %v", s.LiveFeedAPI.EventReceiverPort))
+	out.WriteString(fmt.Sprintf("\n    EventSenderPort          %v", s.LiveFeedAPI.EventSenderPort))
 	out.WriteString(fmt.Sprintf("\n    EventFormat              %v", s.LiveFeedAPI.EventFormat))
 	out.WriteString(fmt.Sprintf("\n    EventBroadcastContent    %v", s.LiveFeedAPI.EventBroadcastContent))
 	out.WriteString(fmt.Sprintf("\n    EventSendStateChange     %v", s.LiveFeedAPI.EventSendStateChange))


### PR DESCRIPTION
Change from @hannemennah  to make the outbound TCP port predictable

This was important when controlling egress from the container