### PR TITLE
Reversing API status code

### DIFF
--- a/wsapi/debugapi.go
+++ b/wsapi/debugapi.go
@@ -30,7 +30,7 @@ func HandleDebug(writer http.ResponseWriter, request *http.Request) {
 	state, err := GetState(request)
 	if err != nil {
 		wsDebugLog.Errorf("failed to extract port from request: %s", err)
-		writer.WriteHeader(http.StatusOK)
+		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
 

--- a/wsapi/wsapi.go
+++ b/wsapi/wsapi.go
@@ -133,7 +133,7 @@ func returnV1Msg(writer http.ResponseWriter, msg string, success bool) {
 }
 
 func handleV1Error(writer http.ResponseWriter, err *primitives.JSONError) {
-	writer.WriteHeader(http.StatusOK)
+	writer.WriteHeader(http.StatusBadRequest)
 	return
 }
 

--- a/wsapi/wsapiV1.go
+++ b/wsapi/wsapiV1.go
@@ -64,7 +64,7 @@ func checkHttpPasswordOkV1(writer http.ResponseWriter, request *http.Request) bo
 		}
 	} else {
 		wsLog.Errorf("failed to get state from request: %s", err)
-		writer.WriteHeader(http.StatusOK)
+		writer.WriteHeader(http.StatusBadRequest)
 		return false
 	}
 	return true

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -41,7 +41,7 @@ func HandleV2(writer http.ResponseWriter, request *http.Request) {
 	state, err := GetState(request)
 	if err != nil {
 		wsLog.Errorf("failed to extract port from request: %s", err)
-		writer.WriteHeader(http.StatusOK)
+		writer.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
@@ -520,7 +520,7 @@ func HandleV2Error(writer http.ResponseWriter, j *primitives.JSON2Request, jErr 
 	}
 	resp.Error = jErr
 
-	writer.WriteHeader(http.StatusOK)
+	writer.WriteHeader(http.StatusBadRequest)
 	_, err := writer.Write([]byte(resp.String()))
 	if err != nil {
 		wsLog.Errorf("failed to write error response: %v", err)


### PR DESCRIPTION
This is a compatibility issue that came to light in testing 6.5.1. PR #897 changed the API to return status code 200 for json-rpc errors, but the factom.js client relies on status codes to determine whether or not a request is an error. Functionality is being changed back to preserve backward compatibility.

Reversing this means the FAT/factom client is no longer fully compatible due to https://github.com/AdamSLevy/jsonrpc2/issues/3. However, this is a fairly benign issue that results in FAT/factom to return a json-parsing error rather than an appropriate error.
