### PR TITLE
Add optional HashType to RawData endpoint

### DIFF
--- a/wsapi/hashtype.go
+++ b/wsapi/hashtype.go
@@ -1,0 +1,69 @@
+package wsapi
+
+import (
+	"fmt"
+	"strings"
+)
+
+type HashType int
+
+const (
+	HashTypeUnspecified HashType = iota
+	HashTypeFCTTx
+	HashTypeECTx
+	HashTypeEntry
+	HashTypeEBlock
+	HashTypeECBlock
+	HashTypeFBlock
+	HashTypeABlock
+	HashTypeDBlock
+)
+
+func (ht HashType) String() string {
+	switch ht {
+	case HashTypeFCTTx:
+		return "Factoid Transaction Hash"
+	case HashTypeECTx:
+		return "Entry Credit Transaction Hash"
+	case HashTypeEntry:
+		return "Entry Hash"
+	case HashTypeEBlock:
+		return "Entry Block KeyMR"
+	case HashTypeECBlock:
+		return "Entry Credit Block KeyMR"
+	case HashTypeFBlock:
+		return "Factoid Block KeyMR"
+	case HashTypeABlock:
+		return "Admin Block KeyMR"
+	case HashTypeDBlock:
+		return "Directory Block KeyMR"
+	default:
+		return "unspecified"
+	}
+}
+
+func (ht *HashType) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "":
+		*ht = HashTypeUnspecified
+	case "fcttx":
+		*ht = HashTypeFCTTx
+	case "ectx":
+		*ht = HashTypeECTx
+	case "entry":
+		*ht = HashTypeEntry
+	case "eblock":
+		*ht = HashTypeEBlock
+	case "ecblock":
+		*ht = HashTypeECBlock
+	case "fblock":
+		*ht = HashTypeFBlock
+	case "ablock":
+		*ht = HashTypeABlock
+	case "dblock":
+		*ht = HashTypeDBlock
+	default:
+		return fmt.Errorf("invalid hash type")
+	}
+	return nil
+}

--- a/wsapi/wsapiStructs.go
+++ b/wsapi/wsapiStructs.go
@@ -294,7 +294,8 @@ type EntryRequest struct {
 }
 
 type HashRequest struct {
-	Hash string `json:"hash"`
+	Hash string   `json:"hash"`
+	Type HashType `json:"type,omitempty"`
 }
 
 type KeyMRRequest struct {

--- a/wsapi/wsapiV2_test.go
+++ b/wsapi/wsapiV2_test.go
@@ -252,6 +252,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		Hash1 string
 		Hash2 string
 		Raw   string
+		Type  HashType
 	}
 
 	toTest := []RawData{}
@@ -268,6 +269,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		panic(err)
 	}
 	raw.Raw = primitives.EncodeBinary(hex)
+	raw.Type = HashTypeABlock
 	toTest = append(toTest, raw) //1
 
 	eBlock := blockSet.EBlock
@@ -279,6 +281,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		panic(err)
 	}
 	raw.Raw = primitives.EncodeBinary(hex)
+	raw.Type = HashTypeEBlock
 	toTest = append(toTest, raw) //2
 
 	ecBlock := blockSet.ECBlock
@@ -290,6 +293,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		panic(err)
 	}
 	raw.Raw = primitives.EncodeBinary(hex)
+	raw.Type = HashTypeECBlock
 	toTest = append(toTest, raw) //3
 
 	fBlock := blockSet.FBlock
@@ -301,6 +305,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		panic(err)
 	}
 	raw.Raw = primitives.EncodeBinary(hex)
+	raw.Type = HashTypeFBlock
 	toTest = append(toTest, raw) //4
 
 	dBlock := blockSet.DBlock
@@ -312,6 +317,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 		panic(err)
 	}
 	raw.Raw = primitives.EncodeBinary(hex)
+	raw.Type = HashTypeDBlock
 	toTest = append(toTest, raw) //5
 
 	//initializing server
@@ -319,20 +325,24 @@ func TestHandleV2GetRaw(t *testing.T) {
 	Start(state)
 
 	for i, v := range toTest {
+		// Once without specifying type
 		data := new(HashRequest)
-		data.Hash = v.Hash1
-		req := primitives.NewJSON2Request("raw-data", 1, data)
+		for j := 0; j < 2; j++ {
+			data.Hash = v.Hash1
+			req := primitives.NewJSON2Request("raw-data", 1, data)
 
-		time.Sleep(time.Millisecond * 100)
-		resp, err := v2Request(req)
-		assert.Nil(t, err)
-		assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v but got %v \nGetRaw %v/%v from Hash1 failed - %v", v.Hash1, v.Raw, i, len(toTest), resp.String())
+			time.Sleep(time.Millisecond * 100)
+			resp, err := v2Request(req)
+			assert.Nil(t, err)
+			assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v but got %v \nGetRaw %v/%v from Hash1 failed - %v", v.Hash1, v.Raw, i, len(toTest), resp.String())
 
-		data.Hash = v.Hash2
-		req = primitives.NewJSON2Request("raw-data", 1, data)
-		resp, err = v2Request(req)
-		assert.Nil(t, err)
-		assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v \nGetRaw %v/%v from Hash2 failed - %v", v.Hash1, i, len(toTest), resp.String())
+			data.Hash = v.Hash2
+			req = primitives.NewJSON2Request("raw-data", 1, data)
+			resp, err = v2Request(req)
+			assert.Nil(t, err)
+			assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v \nGetRaw %v/%v from Hash2 failed - %v", v.Hash1, i, len(toTest), resp.String())
+		}
+		data.Type = v.Type // Once with Type
 	}
 }
 


### PR DESCRIPTION
This allows the client to optionally specify the hash type when using the "raw-data" API method. For example, a user typically knows what the hash they are searching for refers to: an entry hash, an EBlock KeyMR, a FCT or EC TX hash. Now they can include that information and reduce needless database look ups. If none is specified, it falls back to searching all of the databases until it finds the hash. This path has also been streamlined.