### PR TITLE
Only check for nil-interface when nil is expected

### DIFF
--- a/common/entryBlock/entry.go
+++ b/common/entryBlock/entry.go
@@ -143,7 +143,8 @@ func (c *Entry) DatabasePrimaryIndex() (rval interfaces.IHash) {
 
 // DatabaseSecondaryIndex always returns nil (ie, no secondary index)
 func (c *Entry) DatabaseSecondaryIndex() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "Entry.DatabaseSecondaryIndex") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "Entry.DatabaseSecondaryIndex") }()
 
 	return nil
 }

--- a/common/entryBlock/entry.go
+++ b/common/entryBlock/entry.go
@@ -143,7 +143,7 @@ func (c *Entry) DatabasePrimaryIndex() (rval interfaces.IHash) {
 
 // DatabaseSecondaryIndex always returns nil (ie, no secondary index)
 func (c *Entry) DatabaseSecondaryIndex() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "Entry.DatabaseSecondaryIndex") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "Entry.DatabaseSecondaryIndex") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/increasebalance.go
+++ b/common/entryCreditBlock/increasebalance.go
@@ -92,7 +92,7 @@ func NewIncreaseBalance() *IncreaseBalance {
 
 // GetEntryHash always returns nil
 func (e *IncreaseBalance) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetEntryHash") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "IncreaseBalance.GetEntryHash") }()
 
 	return nil
 }
@@ -117,8 +117,6 @@ func (e *IncreaseBalance) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *IncreaseBalance) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetSigHash") }()
-
 	return nil
 }
 

--- a/common/entryCreditBlock/increasebalance.go
+++ b/common/entryCreditBlock/increasebalance.go
@@ -92,7 +92,8 @@ func NewIncreaseBalance() *IncreaseBalance {
 
 // GetEntryHash always returns nil
 func (e *IncreaseBalance) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "IncreaseBalance.GetEntryHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetEntryHash") }()
 
 	return nil
 }
@@ -117,7 +118,8 @@ func (e *IncreaseBalance) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *IncreaseBalance) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "IncreaseBalance.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/increasebalance.go
+++ b/common/entryCreditBlock/increasebalance.go
@@ -117,6 +117,8 @@ func (e *IncreaseBalance) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *IncreaseBalance) GetSigHash() (rval interfaces.IHash) {
+	defer func() { rval = primitives.CheckNilInterface(rval, "IncreaseBalance.GetSigHash") }()
+
 	return nil
 }
 

--- a/common/entryCreditBlock/minutenumber.go
+++ b/common/entryCreditBlock/minutenumber.go
@@ -71,7 +71,7 @@ func (e *MinuteNumber) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *MinuteNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "MinuteNumber.GetSigHash") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "MinuteNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/minutenumber.go
+++ b/common/entryCreditBlock/minutenumber.go
@@ -71,7 +71,8 @@ func (e *MinuteNumber) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *MinuteNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "MinuteNumber.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "MinuteNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/serverindexnumber.go
+++ b/common/entryCreditBlock/serverindexnumber.go
@@ -79,14 +79,16 @@ func (e *ServerIndexNumber) GetHash() (rval interfaces.IHash) {
 
 // GetEntryHash always returns nil
 func (e *ServerIndexNumber) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "ServerIndexNumber.GetEntryHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetEntryHash") }()
 
 	return nil
 }
 
 // GetSigHash always returns nil
 func (e *ServerIndexNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "ServerIndexNumber.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/serverindexnumber.go
+++ b/common/entryCreditBlock/serverindexnumber.go
@@ -79,14 +79,14 @@ func (e *ServerIndexNumber) GetHash() (rval interfaces.IHash) {
 
 // GetEntryHash always returns nil
 func (e *ServerIndexNumber) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetEntryHash") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "ServerIndexNumber.GetEntryHash") }()
 
 	return nil
 }
 
 // GetSigHash always returns nil
 func (e *ServerIndexNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetSigHash") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "ServerIndexNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/messages/electionMsgs/timeoutInternal.go
+++ b/common/messages/electionMsgs/timeoutInternal.go
@@ -241,7 +241,7 @@ func (m *TimeoutInternal) ElectionProcess(is interfaces.IState, elect interfaces
 }
 
 func (m *TimeoutInternal) GetServerID() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "TimeoutInternal.GetServerID") }()
+	defer func() { rval = primitives.CheckNilInterface(rval, "TimeoutInternal.GetServerID") }()
 
 	return nil
 }

--- a/common/messages/electionMsgs/timeoutInternal.go
+++ b/common/messages/electionMsgs/timeoutInternal.go
@@ -241,7 +241,8 @@ func (m *TimeoutInternal) ElectionProcess(is interfaces.IState, elect interfaces
 }
 
 func (m *TimeoutInternal) GetServerID() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNilInterface(rval, "TimeoutInternal.GetServerID") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "TimeoutInternal.GetServerID") }()
 
 	return nil
 }

--- a/common/primitives/hash.go
+++ b/common/primitives/hash.go
@@ -78,14 +78,6 @@ func CheckNil(h interfaces.IHash, caller string) (rval interfaces.IHash) {
 	return h
 }
 
-func CheckNilInterface(h interfaces.IHash, caller string) (rval interfaces.IHash) {
-	if h != nil && reflect.ValueOf(h).IsNil() {
-		LogNilHashBug(caller + "() returned an interface  nil")
-		return nil // convert an interface that is nil to a nil interface
-	}
-	return h
-}
-
 // IsHashNil returns true if receiver is nil, or the hash is zero
 func (h *Hash) IsHashNil() bool {
 	return h == nil || reflect.ValueOf(h).IsNil()

--- a/common/primitives/hash.go
+++ b/common/primitives/hash.go
@@ -78,6 +78,14 @@ func CheckNil(h interfaces.IHash, caller string) (rval interfaces.IHash) {
 	return h
 }
 
+func CheckNilInterface(h interfaces.IHash, caller string) (rval interfaces.IHash) {
+	if h != nil && reflect.ValueOf(h).IsNil() {
+		LogNilHashBug(caller + "() returned an interface  nil")
+		return nil // convert an interface that is nil to a nil interface
+	}
+	return h
+}
+
 // IsHashNil returns true if receiver is nil, or the hash is zero
 func (h *Hash) IsHashNil() bool {
 	return h == nil || reflect.ValueOf(h).IsNil()


### PR DESCRIPTION
In the hunt for pokemon bugs, functions that return an IHash perform the nil interface check. This turns a nil-interface into a nil and also prints a warning if the value is an actual nil. However, there are a couple of functions that explicitly return a "nil" hash right now, which now have a status message printed out.

One of those messages occurs when entries are made to the EC block:
```
MinuteNumber.GetSigHash() returned a nil for IHash. Called from goroutine 2645-/common/entryCreditBlock/minutenumber.go:74
MinuteNumber.GetSigHash() returned a nil for IHash. Called from goroutine 2645-/common/entryCreditBlock/minutenumber.go:74
MinuteNumber.GetSigHash() returned a nil for IHash. Called from goroutine 2645-/common/entryCreditBlock/minutenumber.go:74
...
```

This PR adds a new function `primitives.CheckNilInterface` that allows the return of nil values without a status message and changes the five functions that explicitly return a nil.

(Note: I think I got all the functions, I searched via regex `^\s+defer func\(\) \{ rval.*$[\n\r\s]+return nil`)