### PR TITLE
[p2p2 6.6.0 beta] Fix control panel unit tests

### DIFF
--- a/Utilities/NetworkTester/NetworkTest.go
+++ b/Utilities/NetworkTester/NetworkTest.go
@@ -66,9 +66,17 @@ func InitNetwork() {
 	exclusive := *exclusivePtr
 	exclusiveIn := *exclusiveInPtr
 	logPort = *logportPtr
-	p2p.NetworkDeadline = time.Duration(*deadlinePtr) * time.Millisecond
 	isp2p = *p2pPtr
 	size = *sizePtr * 1024
+
+	conf := p2p.DefaultP2PConfiguration()
+	conf.ListenPort = port
+	conf.PeerCacheFile = "peers.json"
+	conf.Network = 1
+	conf.SeedURL = ""
+	conf.Special = peers
+	conf.ReadDeadline = time.Duration(*deadlinePtr) * time.Millisecond
+	conf.WriteDeadline = time.Duration(*deadlinePtr) * time.Millisecond
 
 	os.Stderr.WriteString("\nnetTest is a standalone program that generates factomd messages (bounce and bounceResponse)\n ")
 	os.Stderr.WriteString("        and sends them to other nodes on the network.  This allows testing of the network\n ")
@@ -81,27 +89,22 @@ func InitNetwork() {
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %s\n", "peers", peers))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "exclusive", exclusive))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "exclusiveIn", exclusiveIn))
-	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "deadline", p2p.NetworkDeadline.Seconds()))
+	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "deadline", conf.ReadDeadline.Seconds()))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %v\n", "p2p", isp2p))
 	os.Stderr.WriteString(fmt.Sprintf("%20s -- %dk\n\n", "size", size/1024))
 
-	connectionMetricsChannel := make(chan interface{}, p2p.StandardChannelSize)
-	ci := p2p.ControllerInit{
-		Port:                     port,
-		PeersFile:                "peers.json",
-		Network:                  1,
-		Exclusive:                exclusive,
-		ExclusiveIn:              exclusiveIn,
-		SeedURL:                  "",
-		ConfigPeers:              peers,
-		ConnectionMetricsChannel: connectionMetricsChannel,
+	network, err := p2p.NewNetwork(conf)
+	if err != nil {
+		panic(err)
 	}
-	p2pNetwork := new(p2p.Controller).Init(ci)
-	p2pNetwork.StartNetwork()
+
+	if err := network.Run(); err != nil {
+		panic(err)
+	}
+
 	// Setup the proxy (Which translates from network parcels to Factom messages, handling addressing for directed messages)
 	p2pProxy = new(engine.P2PProxy).Init("testnode", "P2P Network").(*engine.P2PProxy)
-	p2pProxy.FromNetwork = p2pNetwork.FromNetwork
-	p2pProxy.ToNetwork = p2pNetwork.ToNetwork
+	p2pProxy.Network = network
 
 	p2pProxy.StartProxy()
 }

--- a/controlPanel/connectionManagement_test.go
+++ b/controlPanel/connectionManagement_test.go
@@ -51,12 +51,12 @@ func TestFormatDuration(t *testing.T) {
 
 func TestTallyTotals(t *testing.T) {
 	cm := NewConnectionsMap()
-	var i uint32
+	var i uint64
 	for i = 0; i < 10; i++ {
-		cm.Connect(fmt.Sprintf("%d", i), NewP2PConnection(i, i, i, i, fmt.Sprintf("%d", i), i))
+		cm.Connect(fmt.Sprintf("%d", i), NewP2PConnection(i, i, i, i, fmt.Sprintf("%d", i), int32(i)))
 	}
 	for i = 10; i < 20; i++ {
-		cm.Disconnect(fmt.Sprintf("%d", i), NewP2PConnection(i, i, i, i, fmt.Sprintf("%d", i), i))
+		cm.Disconnect(fmt.Sprintf("%d", i), NewP2PConnection(i, i, i, i, fmt.Sprintf("%d", i), int32(i)))
 	}
 	cm.TallyTotals()
 	cm.Lock.Lock()
@@ -107,12 +107,12 @@ func TestTallyTotals(t *testing.T) {
 	AllConnectionsString()
 }
 
-func PopulateConnectionChan(total uint32, connections chan interface{}) {
+func PopulateConnectionChan(total uint32, connections chan map[string]p2p.PeerMetrics) {
 	time.Sleep(3 * time.Second)
 	var i uint32
-	temp := make(map[string]p2p.ConnectionMetrics)
+	temp := make(map[string]p2p.PeerMetrics)
 	for i = 0; i < total; i++ {
-		peer := NewSeededP2PConnection(i)
+		peer := NewSeededP2PConnection(uint64(i))
 		if i%2 == 0 {
 			peer.MomentConnected = time.Now().Add(-(time.Duration(i)) * time.Hour)
 		} else {
@@ -127,12 +127,12 @@ func TestAccessors(t *testing.T) {
 	cm := NewConnectionsMap()
 
 	// Test Disconnect
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		peer := NewSeededP2PConnection(count)
 		cm.Disconnect(peer.PeerAddress, peer)
 	}
 
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		cp := cm.GetDisconnectedCopy()
 		if len(cp) != 2 {
 			t.Error("Should have 2 Disconnections")
@@ -140,12 +140,12 @@ func TestAccessors(t *testing.T) {
 	}
 
 	// Test Connect
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		peer := NewSeededP2PConnection(count)
 		cm.AddConnection(peer.PeerAddress, *peer)
 	}
 
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		cp := cm.GetConnectedCopy()
 		if len(cp) != 2 {
 			t.Error("Should have 2 connections")
@@ -158,17 +158,17 @@ func TestAccessors(t *testing.T) {
 	}
 
 	// Connect with nil, but exists in disconnections
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		peer := NewSeededP2PConnection(count)
 		cm.Disconnect(peer.PeerAddress, peer)
 	}
 
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		peer := NewSeededP2PConnection(count)
 		cm.Connect(peer.PeerAddress, nil)
 	}
 
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		cp := cm.GetConnectedCopy()
 		if len(cp) != 2 {
 			t.Error("Should have 2 Connections")
@@ -176,12 +176,12 @@ func TestAccessors(t *testing.T) {
 	}
 
 	// Disconnect with nil, but exists in connections
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		peer := NewSeededP2PConnection(count)
 		cm.Disconnect(peer.PeerAddress, nil)
 	}
 
-	for count := uint32(0); count < 2; count++ {
+	for count := uint64(0); count < 2; count++ {
 		cp := cm.GetDisconnectedCopy()
 		if len(cp) != 2 {
 			t.Error("Should have 2 Connections")
@@ -193,18 +193,18 @@ func TestAccessors(t *testing.T) {
 // Absurd map accessing
 func TestConcurrency(t *testing.T) {
 	cm := NewConnectionsMap()
-	connectionMap := make(map[string]p2p.ConnectionMetrics)
-	var count uint32
+	connectionMap := make(map[string]p2p.PeerMetrics)
+	var count uint64
 	for count = 0; count < 100; count++ {
 		peer := NewSeededP2PConnection(count)
 
 		connectionMap[peer.PeerAddress] = *peer
 	}
-	var i uint32
+	var i uint64
 	for i = 0; i < 100; i++ {
 		// Random Connections
 		go func() {
-			randPeers := make([]p2p.ConnectionMetrics, 0)
+			randPeers := make([]p2p.PeerMetrics, 0)
 			for ii := 0; ii < 10; ii++ {
 				randPeer := NewRandomP2PConnection()
 				cm.Connect(randPeer.PeerAddress, randPeer)
@@ -228,8 +228,8 @@ func TestConcurrency(t *testing.T) {
 		}()
 
 		go func() {
-			randPeers := make([]p2p.ConnectionMetrics, 0)
-			var ii uint32
+			randPeers := make([]p2p.PeerMetrics, 0)
+			var ii uint64
 			for ii = 0; ii < 10; ii++ {
 				randPeer1 := NewSeededP2PConnection(ii)
 				cm.Connect(randPeer1.PeerAddress, randPeer1)
@@ -255,7 +255,7 @@ func TestConcurrency(t *testing.T) {
 			}
 		}()
 		go func() {
-			var ii uint32
+			var ii uint64
 			for ii = 30; ii < 60; ii++ {
 				p := NewRandomP2PConnection()
 				ps := NewSeededP2PConnection(ii)
@@ -265,7 +265,7 @@ func TestConcurrency(t *testing.T) {
 			}
 		}()
 		go func() {
-			var ii uint32
+			var ii uint64
 			for ii = 30; ii < 60; ii++ {
 				p := NewRandomP2PConnection()
 				ps := NewSeededP2PConnection(ii)
@@ -276,7 +276,7 @@ func TestConcurrency(t *testing.T) {
 		}()
 
 		go func() {
-			var ii uint32
+			var ii uint64
 			for ii = 100; ii < 120; ii++ {
 				cm.UpdateConnections(connectionMap)
 			}
@@ -285,25 +285,25 @@ func TestConcurrency(t *testing.T) {
 	}
 }
 
-func NewRandomP2PConnection() *p2p.ConnectionMetrics {
-	con := NewP2PConnection(rand.Uint32(), rand.Uint32(), rand.Uint32(), rand.Uint32(), string(rand.Uint32()), rand.Uint32())
+func NewRandomP2PConnection() *p2p.PeerMetrics {
+	con := NewP2PConnection(rand.Uint64(), rand.Uint64(), rand.Uint64(), rand.Uint64(), string(rand.Uint32()), rand.Int31())
 	return con
 }
 
-func NewSeededP2PConnection(seed uint32) *p2p.ConnectionMetrics {
-	con := NewP2PConnection(seed, seed, seed, seed, fmt.Sprintf("%d", seed), seed)
+func NewSeededP2PConnection(seed uint64) *p2p.PeerMetrics {
+	con := NewP2PConnection(seed, seed, seed, seed, fmt.Sprintf("%d", seed), int32(seed))
 	return con
 }
 
-func NewP2PConnection(bs uint32, br uint32, ms uint32, mr uint32, addr string, pq uint32) *p2p.ConnectionMetrics {
-	pc := new(p2p.ConnectionMetrics)
+func NewP2PConnection(bs uint64, br uint64, ms uint64, mr uint64, addr string, pq int32) *p2p.PeerMetrics {
+	pc := new(p2p.PeerMetrics)
 	pc.MomentConnected = time.Now()
 	pc.BytesSent = bs
 	pc.BytesReceived = br
 	pc.MessagesSent = ms
 	pc.MessagesReceived = mr
 	pc.PeerAddress = "10.1.1" + addr
-	pc.PeerQuality = int32(pq)
+	pc.PeerQuality = pq
 
 	return pc
 }

--- a/controlPanel/controlPanel_test.go
+++ b/controlPanel/controlPanel_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 	. "github.com/FactomProject/factomd/controlPanel"
 	"github.com/FactomProject/factomd/database/databaseOverlay"
+	"github.com/FactomProject/factomd/p2p"
+
 	//"github.com/FactomProject/factomd/p2p"
 	"github.com/FactomProject/factomd/state"
 	//"github.com/FactomProject/factomd/common/primitives/random"
@@ -64,7 +66,7 @@ func addTrans(rc *LastDirectoryBlockTransactions) {
 func TestControlPanel(t *testing.T) {
 	if LongTest {
 		var i uint32
-		connections := make(chan interface{})
+		connections := make(chan map[string]p2p.PeerMetrics)
 		emptyState := CreateAndPopulateTestStateAndStartValidator()
 
 		gitBuild := "Test Is Running"

--- a/events/eventEmitter_test.go
+++ b/events/eventEmitter_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/FactomProject/factomd/events/eventconfig"
 	"github.com/FactomProject/factomd/events/eventinput"
 	"github.com/FactomProject/factomd/events/eventmessages/generated/eventmessages"
-	"github.com/FactomProject/factomd/p2p"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -41,7 +40,7 @@ func TestEventEmitter_Send(t *testing.T) {
 		"not-running": {
 			Emitter: &eventEmitter{
 				eventSender: &mockEventSender{
-					eventsOutQueue: make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize),
+					eventsOutQueue: make(chan *eventmessages.FactomEvent, 5000),
 				},
 				parentState: StateMock{
 					RunState: runstate.Stopping,
@@ -56,7 +55,7 @@ func TestEventEmitter_Send(t *testing.T) {
 		"nil-event": {
 			Emitter: &eventEmitter{
 				eventSender: &mockEventSender{
-					eventsOutQueue:      make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize),
+					eventsOutQueue:      make(chan *eventmessages.FactomEvent, 5000),
 					replayDuringStartup: true,
 				},
 				parentState: StateMock{},
@@ -70,7 +69,7 @@ func TestEventEmitter_Send(t *testing.T) {
 		"mute-replay-starting": {
 			Emitter: &eventEmitter{
 				eventSender: &mockEventSender{
-					eventsOutQueue:      make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize),
+					eventsOutQueue:      make(chan *eventmessages.FactomEvent, 5000),
 					replayDuringStartup: false,
 				},
 				parentState: StateMock{

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/FactomProject/factomd/database/databaseOverlay"
 	"github.com/FactomProject/factomd/events/eventconfig"
 	"github.com/FactomProject/factomd/events/eventmessages/generated/eventmessages"
-	"github.com/FactomProject/factomd/p2p"
 	"github.com/FactomProject/factomd/testHelper"
 	"github.com/stretchr/testify/assert"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func TestUpdateState(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -68,7 +67,7 @@ func TestUpdateState(t *testing.T) {
 }
 
 func TestAddToAndDeleteFromHolding(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -110,7 +109,7 @@ func TestAddToAndDeleteFromHolding(t *testing.T) {
 }
 
 func TestAddToProcessList(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -152,7 +151,7 @@ func TestAddToProcessList(t *testing.T) {
 }
 
 func TestEmitDirectoryBlockEventsFromHeightRange(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -185,7 +184,7 @@ func TestEmitDirectoryBlockEventsFromHeightRange(t *testing.T) {
 }
 
 func TestEmitDirectoryBlockStateEventsFromHeight(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -218,7 +217,7 @@ func TestEmitDirectoryBlockStateEventsFromHeight(t *testing.T) {
 }
 
 func TestEmitDirectoryBlockAnchorEvent(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,
@@ -279,7 +278,7 @@ func TestExecuteMessage(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			// set mock service to receive events
-			eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+			eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 			mockSender := &mockEventSender{
 				eventsOutQueue:      eventQueue,
 				replayDuringStartup: true,
@@ -304,7 +303,7 @@ func TestExecuteMessage(t *testing.T) {
 }
 
 func TestEmitProcessListEvent(t *testing.T) {
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	mockSender := &mockEventSender{
 		eventsOutQueue:      eventQueue,
 		replayDuringStartup: true,

--- a/events/eventservices/eventSender_test.go
+++ b/events/eventservices/eventSender_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/events/eventconfig"
 	"github.com/FactomProject/factomd/events/eventmessages/generated/eventmessages"
-	"github.com/FactomProject/factomd/p2p"
 	"github.com/FactomProject/factomd/util/atomic"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -100,7 +99,7 @@ func TestEventService_ProcessEventsChannelNoSent(t *testing.T) {
 	redialSleepDuration = 1 * time.Millisecond
 	sendRetries = 1
 
-	eventQueue := make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize)
+	eventQueue := make(chan *eventmessages.FactomEvent, 5000)
 	eventService := &eventSender{
 		eventsOutQueue: eventQueue,
 		params: &EventServiceParams{
@@ -336,7 +335,7 @@ func TestEventService_ConnectAndShutdown(t *testing.T) {
 	}()
 
 	eventService := &eventSender{
-		eventsOutQueue: make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize),
+		eventsOutQueue: make(chan *eventmessages.FactomEvent, 5000),
 		params: &EventServiceParams{
 			Protocol: "tcp",
 			Address:  address,
@@ -550,7 +549,7 @@ func BenchmarkEventService_Send(b *testing.B) {
 	}
 
 	eventService := &eventSender{
-		eventsOutQueue:          make(chan *eventmessages.FactomEvent, p2p.StandardChannelSize),
+		eventsOutQueue:          make(chan *eventmessages.FactomEvent, 5000),
 		connection:              client,
 		params:                  params,
 		droppedFromQueueCounter: prometheus.NewCounter(prometheus.CounterOpts{}),

--- a/p2p/controller_connections_test.go
+++ b/p2p/controller_connections_test.go
@@ -246,7 +246,7 @@ func Test_controller_listen(t *testing.T) {
 
 	done := make(chan bool, 1)
 	go func() {
-		go n1.controller.listen()
+		n1.controller.listen()
 		done <- true
 	}()
 

--- a/p2p/controller_connections_test.go
+++ b/p2p/controller_connections_test.go
@@ -244,11 +244,16 @@ func Test_controller_listen(t *testing.T) {
 	n1.conf.BindIP = ep.IP
 	n1.conf.ListenPort = ep.Port
 
+	start := make(chan bool, 1)
 	done := make(chan bool, 1)
 	go func() {
+		start <- true
 		n1.controller.listen()
 		done <- true
 	}()
+
+	<-start
+	time.Sleep(time.Millisecond * 100)
 
 	con, err := net.Dial("tcp", ep.String())
 	if err != nil {

--- a/p2p/util_test.go
+++ b/p2p/util_test.go
@@ -18,7 +18,7 @@ func TestIP2Location(t *testing.T) {
 		want    uint32
 		wantErr bool
 	}{
-		{"localhost", args{"localhost"}, 1, false},
+		//{"localhost", args{"localhost"}, 1, false}, // this could be either ipv4 or ipv6, disable it
 		{"localhost ipv4", args{"127.0.0.1"}, 2130706433, false},
 		{"min ip", args{"0.0.0.0"}, 0, false},
 		{"max ip", args{"255.255.255.255"}, 4294967295, false},


### PR DESCRIPTION
Looks like there were a couple of unit tests not passing:
* the control panel tests were using the old p2p metrics struct
* the live event api relied on a p2p global variable to set their channel size for some reason
* Test_controller_listen ran into a goroutine race condition that failed on circle but not my dev machine
* Testing IP lookup failed due to differences in ipv4 and ipv6 (that test is disabled now since we can't guarantee which one is used)