### PR TITLE
Fixing flaky wsapi unit tests

### DIFF
--- a/wsapi/server.go
+++ b/wsapi/server.go
@@ -34,7 +34,6 @@ func InitServer(state interfaces.IState) *Server {
 	server := Server{State: state, router: router, tlsEnabled: tlsIsEnabled, certFile: certFile, keyFile: keyFile, Port: port}
 
 	if tlsIsEnabled {
-		router.Schemes("HTTPS")
 		wsLog.Info("Starting encrypted API server")
 		if !fileExists(keyFile) && !fileExists(certFile) {
 			err := genCertPair(certFile, keyFile, state.GetFactomdLocations())

--- a/wsapi/wsapi_test.go
+++ b/wsapi/wsapi_test.go
@@ -18,21 +18,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func waitUntilStarted(t *testing.T, url string, limit time.Duration) {
+func waitUntilStarted(t *testing.T, url string, timeout time.Duration) {
 	transCfg := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // ignore expired SSL certificates
 	}
 	client := &http.Client{Transport: transCfg}
 
 	start := time.Now()
-	for time.Since(start) < limit {
+	for time.Since(start) < timeout {
 		_, err := client.Get(url)
 		if err == nil {
 			return
 		}
 		time.Sleep(time.Millisecond * 100)
 	}
-	t.Fatalf("unable to connect to %s in %s", url, limit)
+	t.Fatalf("unable to connect to %s in %s", url, timeout)
 }
 
 func TestGetEndpoints(t *testing.T) {


### PR DESCRIPTION
There were two issues at play here:
1. The flaky test was caused by a race condition between the unit test making a http request and the http server starting. This is remedied by the `waitUntilStarted` function, which polls the server every 100ms for the specified duration. The tests now wait for five seconds for the server to start and only then run the tests
2. The wsapi https feature just doesn't work and always returns a 404. This is due to: https://github.com/FactomProject/factomd/blob/ee7ab6b5fb053eefc83ff4f5e223d897f9277faa/wsapi/server.go#L37 This line adds a route for "https://*" but without a handler, shadowing all subsequent routes. The line has been removed again.