### PR TITLE
[P2P2] Small updates

### DIFF
--- a/p2p/configuration.go
+++ b/p2p/configuration.go
@@ -163,7 +163,7 @@ func DefaultP2PConfiguration() (c Configuration) {
 	c.ProtocolVersion = 10
 	c.ProtocolVersionMinimum = 9
 
-	c.ChannelCapacity = 50
+	c.ChannelCapacity = 1000
 
 	c.EnablePrometheus = true
 	return

--- a/p2p/protocolV11.go
+++ b/p2p/protocolV11.go
@@ -83,10 +83,8 @@ func (v11 *ProtocolV11) ReadHandshake() (*Handshake, error) {
 }
 
 func (v11 *ProtocolV11) readCheck(data []byte) error {
-	if n, err := v11.rw.Read(data); err != nil {
+	if _, err := io.ReadFull(v11.rw, data); err != nil {
 		return err
-	} else if n != len(data) {
-		return fmt.Errorf("unable to read buffer (%d of %d)", n, len(data))
 	}
 	return nil
 }


### PR DESCRIPTION
Both of these surfaced during the testing for my blog:
* Raising the channel capacity allows for higher burst transmissions in the worst case scenario
* V11 broke during high traffic because the code didn't allow for partial reads. switching to io.ReadFull delegates responsibility for partial-reads to golang