### PR TITLE
Make raw data optional in API Requests

### DIFF
--- a/wsapi/wsapiStructs.go
+++ b/wsapi/wsapiStructs.go
@@ -267,6 +267,7 @@ type AddressRequest struct {
 
 type HeightRequest struct {
 	Height int64 `json:"height"`
+	NoRaw  bool  `json:"noraw,omitempty"`
 }
 
 type HeightOrHashRequest struct {
@@ -288,6 +289,7 @@ type HashRequest struct {
 
 type KeyMRRequest struct {
 	KeyMR string `json:"keymr"`
+	NoRaw bool   `json:"noraw,omitempty"`
 }
 
 type KeyRequest struct {

--- a/wsapi/wsapiStructs.go
+++ b/wsapi/wsapiStructs.go
@@ -274,11 +274,6 @@ func (hr *HeightRequest) IncludeRaw() bool {
 	return !hr.NoRaw
 }
 
-type ReplayRequest struct {
-	StartHeight uint32 `json:"startheight"`
-	EndHeight   uint32 `json:"endheight,omitempty"`
-}
-
 type HeightOrHashRequest struct {
 	Height *int64 `json:"height,omitempty"`
 	Hash   string `json:"hash,omitempty"`

--- a/wsapi/wsapiStructs.go
+++ b/wsapi/wsapiStructs.go
@@ -270,6 +270,15 @@ type HeightRequest struct {
 	NoRaw  bool  `json:"noraw,omitempty"`
 }
 
+func (hr *HeightRequest) IncludeRaw() bool {
+	return !hr.NoRaw
+}
+
+type ReplayRequest struct {
+	StartHeight uint32 `json:"startheight"`
+	EndHeight   uint32 `json:"endheight,omitempty"`
+}
+
 type HeightOrHashRequest struct {
 	Height *int64 `json:"height,omitempty"`
 	Hash   string `json:"hash,omitempty"`
@@ -290,6 +299,10 @@ type HashRequest struct {
 type KeyMRRequest struct {
 	KeyMR string `json:"keymr"`
 	NoRaw bool   `json:"noraw,omitempty"`
+}
+
+func (kr *KeyMRRequest) IncludeRaw() bool {
+	return !kr.NoRaw
 }
 
 type KeyRequest struct {

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -213,7 +213,7 @@ func HandleV2DBlockByHeight(state interfaces.IState, params interface{}) (interf
 	}
 	resp.DBlock = b
 
-	if !heightRequest.NoRaw {
+	if heightRequest.IncludeRaw() {
 		raw, err := block.MarshalBinary()
 		if err != nil {
 			return nil, NewInternalError()
@@ -249,7 +249,7 @@ func HandleV2EntryCreditBlock(state interfaces.IState, params interface{}) (inte
 		return nil, NewBlockNotFoundError()
 	}
 
-	return ECBlockToResp(block, keymr.NoRaw)
+	return ECBlockToResp(block, keymr.IncludeRaw())
 }
 
 func HandleV2ECBlockByHeight(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
@@ -272,15 +272,15 @@ func HandleV2ECBlockByHeight(state interfaces.IState, params interface{}) (inter
 		return nil, NewBlockNotFoundError()
 	}
 
-	return ECBlockToResp(block, heightRequest.NoRaw)
+	return ECBlockToResp(block, heightRequest.IncludeRaw())
 }
 
-func ECBlockToResp(block interfaces.IEntryCreditBlock, noraw bool) (interface{}, *primitives.JSONError) {
+func ECBlockToResp(block interfaces.IEntryCreditBlock, includeRaw bool) (interface{}, *primitives.JSONError) {
 
 	resp := new(EntryCreditBlockResponse)
 	resp.ECBlock.Body = block.GetBody()
 	resp.ECBlock.Header = block.GetHeader()
-	if !noraw {
+	if includeRaw {
 		raw, err := block.MarshalBinary()
 		if err != nil {
 			return nil, NewInternalError()
@@ -325,7 +325,7 @@ func HandleV2FactoidBlock(state interfaces.IState, params interface{}) (interfac
 		return nil, NewBlockNotFoundError()
 	}
 
-	return fBlockToResp(block, keymr.NoRaw)
+	return fBlockToResp(block, keymr.IncludeRaw())
 }
 
 // Cached response for genesis fblock
@@ -360,7 +360,7 @@ func HandleV2FBlockByHeight(state interfaces.IState, params interface{}) (interf
 		return nil, NewBlockNotFoundError()
 	}
 
-	resp, jerr := fBlockToResp(block, heightRequest.NoRaw)
+	resp, jerr := fBlockToResp(block, heightRequest.IncludeRaw())
 	if jerr != nil {
 		return nil, jerr
 	}
@@ -373,7 +373,7 @@ func HandleV2FBlockByHeight(state interfaces.IState, params interface{}) (interf
 	return resp, nil
 }
 
-func fBlockToResp(block interfaces.IFBlock, noraw bool) (interface{}, *primitives.JSONError) {
+func fBlockToResp(block interfaces.IFBlock, includeRaw bool) (interface{}, *primitives.JSONError) {
 	resp := new(BlockHeightResponse)
 	b, err := ObjectToJStruct(block)
 	if err != nil {
@@ -394,7 +394,7 @@ func fBlockToResp(block interfaces.IFBlock, noraw bool) (interface{}, *primitive
 	}
 
 	resp.FBlock = b
-	if !noraw {
+	if includeRaw {
 		raw, err := block.MarshalBinary()
 		if err != nil {
 			return nil, NewInternalError()
@@ -435,7 +435,7 @@ func HandleV2AdminBlock(state interfaces.IState, params interface{}) (interface{
 		return nil, NewBlockNotFoundError()
 	}
 
-	return aBlockToResp(block, keymr.NoRaw)
+	return aBlockToResp(block, keymr.IncludeRaw())
 }
 
 func HandleV2ABlockByHeight(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
@@ -458,17 +458,17 @@ func HandleV2ABlockByHeight(state interfaces.IState, params interface{}) (interf
 		return nil, NewBlockNotFoundError()
 	}
 
-	return aBlockToResp(block, heightRequest.NoRaw)
+	return aBlockToResp(block, heightRequest.IncludeRaw())
 }
 
-func aBlockToResp(block interfaces.IAdminBlock, noraw bool) (interface{}, *primitives.JSONError) {
+func aBlockToResp(block interfaces.IAdminBlock, includeRaw bool) (interface{}, *primitives.JSONError) {
 	resp := new(BlockHeightResponse)
 	b, err := ObjectToJStruct(block)
 	if err != nil {
 		return nil, NewInternalError()
 	}
 	resp.ABlock = b
-	if !noraw {
+	if includeRaw {
 		raw, err := block.MarshalBinary()
 		if err != nil {
 			return nil, NewInternalError()

--- a/wsapi/wsapiV2.go
+++ b/wsapi/wsapiV2.go
@@ -206,18 +206,20 @@ func HandleV2DBlockByHeight(state interfaces.IState, params interface{}) (interf
 		return nil, NewBlockNotFoundError()
 	}
 
-	raw, err := block.MarshalBinary()
-	if err != nil {
-		return nil, NewInternalError()
-	}
-
 	resp := new(BlockHeightResponse)
 	b, err := ObjectToJStruct(block)
 	if err != nil {
 		return nil, NewInternalError()
 	}
 	resp.DBlock = b
-	resp.RawData = hex.EncodeToString(raw)
+
+	if !heightRequest.NoRaw {
+		raw, err := block.MarshalBinary()
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		resp.RawData = hex.EncodeToString(raw)
+	}
 
 	return resp, nil
 }
@@ -247,7 +249,7 @@ func HandleV2EntryCreditBlock(state interfaces.IState, params interface{}) (inte
 		return nil, NewBlockNotFoundError()
 	}
 
-	return ECBlockToResp(block)
+	return ECBlockToResp(block, keymr.NoRaw)
 }
 
 func HandleV2ECBlockByHeight(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
@@ -270,19 +272,21 @@ func HandleV2ECBlockByHeight(state interfaces.IState, params interface{}) (inter
 		return nil, NewBlockNotFoundError()
 	}
 
-	return ECBlockToResp(block)
+	return ECBlockToResp(block, heightRequest.NoRaw)
 }
 
-func ECBlockToResp(block interfaces.IEntryCreditBlock) (interface{}, *primitives.JSONError) {
-	raw, err := block.MarshalBinary()
-	if err != nil {
-		return nil, NewInternalError()
-	}
+func ECBlockToResp(block interfaces.IEntryCreditBlock, noraw bool) (interface{}, *primitives.JSONError) {
 
 	resp := new(EntryCreditBlockResponse)
 	resp.ECBlock.Body = block.GetBody()
 	resp.ECBlock.Header = block.GetHeader()
-	resp.RawData = hex.EncodeToString(raw)
+	if !noraw {
+		raw, err := block.MarshalBinary()
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		resp.RawData = hex.EncodeToString(raw)
+	}
 	tmpHash, err := block.GetFullHash()
 	if err != nil {
 		return nil, NewInternalError()
@@ -321,7 +325,7 @@ func HandleV2FactoidBlock(state interfaces.IState, params interface{}) (interfac
 		return nil, NewBlockNotFoundError()
 	}
 
-	return fBlockToResp(block)
+	return fBlockToResp(block, keymr.NoRaw)
 }
 
 // Cached response for genesis fblock
@@ -356,7 +360,7 @@ func HandleV2FBlockByHeight(state interfaces.IState, params interface{}) (interf
 		return nil, NewBlockNotFoundError()
 	}
 
-	resp, jerr := fBlockToResp(block)
+	resp, jerr := fBlockToResp(block, heightRequest.NoRaw)
 	if jerr != nil {
 		return nil, jerr
 	}
@@ -369,12 +373,7 @@ func HandleV2FBlockByHeight(state interfaces.IState, params interface{}) (interf
 	return resp, nil
 }
 
-func fBlockToResp(block interfaces.IFBlock) (interface{}, *primitives.JSONError) {
-	raw, err := block.MarshalBinary()
-	if err != nil {
-		return nil, NewInternalError()
-	}
-
+func fBlockToResp(block interfaces.IFBlock, noraw bool) (interface{}, *primitives.JSONError) {
 	resp := new(BlockHeightResponse)
 	b, err := ObjectToJStruct(block)
 	if err != nil {
@@ -395,7 +394,13 @@ func fBlockToResp(block interfaces.IFBlock) (interface{}, *primitives.JSONError)
 	}
 
 	resp.FBlock = b
-	resp.RawData = hex.EncodeToString(raw)
+	if !noraw {
+		raw, err := block.MarshalBinary()
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		resp.RawData = hex.EncodeToString(raw)
+	}
 
 	return resp, nil
 }
@@ -430,7 +435,7 @@ func HandleV2AdminBlock(state interfaces.IState, params interface{}) (interface{
 		return nil, NewBlockNotFoundError()
 	}
 
-	return aBlockToResp(block)
+	return aBlockToResp(block, keymr.NoRaw)
 }
 
 func HandleV2ABlockByHeight(state interfaces.IState, params interface{}) (interface{}, *primitives.JSONError) {
@@ -453,22 +458,23 @@ func HandleV2ABlockByHeight(state interfaces.IState, params interface{}) (interf
 		return nil, NewBlockNotFoundError()
 	}
 
-	return aBlockToResp(block)
+	return aBlockToResp(block, heightRequest.NoRaw)
 }
 
-func aBlockToResp(block interfaces.IAdminBlock) (interface{}, *primitives.JSONError) {
-	raw, err := block.MarshalBinary()
-	if err != nil {
-		return nil, NewInternalError()
-	}
-
+func aBlockToResp(block interfaces.IAdminBlock, noraw bool) (interface{}, *primitives.JSONError) {
 	resp := new(BlockHeightResponse)
 	b, err := ObjectToJStruct(block)
 	if err != nil {
 		return nil, NewInternalError()
 	}
 	resp.ABlock = b
-	resp.RawData = hex.EncodeToString(raw)
+	if !noraw {
+		raw, err := block.MarshalBinary()
+		if err != nil {
+			return nil, NewInternalError()
+		}
+		resp.RawData = hex.EncodeToString(raw)
+	}
 
 	return resp, nil
 }

--- a/wsapi/wsapiV2_test.go
+++ b/wsapi/wsapiV2_test.go
@@ -489,7 +489,7 @@ func Test_ecBlockToResp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			got, got1 := ECBlockToResp(tt.args.block, false)
+			got, got1 := ECBlockToResp(tt.args.block, true)
 			assert.True(t, reflect.DeepEqual(got, tt.want), "ecBlockToResp() got = %v, want %v", got, tt.want)
 			assert.True(t, reflect.DeepEqual(got1, tt.want1), "ecBlockToResp() got1 = %v, want %v", got1, tt.want1)
 		})

--- a/wsapi/wsapiV2_test.go
+++ b/wsapi/wsapiV2_test.go
@@ -489,7 +489,7 @@ func Test_ecBlockToResp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			got, got1 := ECBlockToResp(tt.args.block)
+			got, got1 := ECBlockToResp(tt.args.block, false)
 			assert.True(t, reflect.DeepEqual(got, tt.want), "ecBlockToResp() got = %v, want %v", got, tt.want)
 			assert.True(t, reflect.DeepEqual(got1, tt.want1), "ecBlockToResp() got1 = %v, want %v", got1, tt.want1)
 		})


### PR DESCRIPTION
I was analyzing D/EC blocks for an unrelated issue and noticed that the API will always send both the json data and the raw message, even if you don't need both.  This wastes quite a bit of bandwidth particularly for EC blocks (they're huge due to PegNet). There already is a "get-raw" endpoint for those that only need the raw data but no way to get just the json without the raw.

This changes the following endpoints:
* admin-block
* factoid-block
* entrycredit-block
* dblock-by-height
* ecblock-by-height
* fblock-by-height
* ablock-by-height

("directory-block" itself doesn't even have a raw option, oddly enough)

It adds an optional "noraw" argument to the json call that accepts either "true" or "false". If "noraw" is not present, everything works as before. If "noraw" is true, the API won't return the raw data.

Benchmarked on a LAN copy of factomd, trying to download 3,000 ecblocks  (240650 to 243650):

|  | Time | Size | 
|---|---|---|
|w/ raw|18.6817609s|286.29941082 Mebibyte|
|no raw|13.887978s|160.519980431 Mebibyte|

A ~44% reduction in size and 26% reduction in transfer duration.