### PR TITLE
[Wax] Make worker.Prefix use safe for outside libraries

### DIFF
--- a/modules/registry/registry.go
+++ b/modules/registry/registry.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"fmt"
-	"runtime"
 	"sync"
 
 	"github.com/FactomProject/factomd/common"
@@ -95,8 +94,7 @@ func (p *process) bindCallbacks(w *worker.Thread, initHandler worker.Handle) {
 
 // Start a new root thread w/ coordinated start/stop callback hooks
 func (p *process) Register(initFunction worker.Handle) {
-	_, file, line, _ := runtime.Caller(1)
-	caller := fmt.Sprintf("%s:%v", file[worker.Prefix:], line)
+	caller := worker.PrettyCallerString()
 	r := p.addThread(common.NilName, "rootThread")
 	r.Caller = caller
 	r.ParentID = r.ID // root threads are their own parent


### PR DESCRIPTION
The worker.init() function determines the `Prefix` from the filepath and tries to apply that to all "caller" strings. This makes the worker package unusable outside of the factomd project, since the runtime.Caller file may yield a string that's shorter than `Prefix`. The cost of the additional check should be negligible.

Changes:
* Turn getting the Caller string into an exported function
* Only shorten the string for calls inside factomd
* Add fallback if no caller can be established