### PR TITLE
[Wax] Stop invalid Coinbase transactions from showing up in pending-transactions

### DIFF
--- a/common/factoid/fblock.go
+++ b/common/factoid/fblock.go
@@ -37,6 +37,8 @@ type FBlock struct {
 	// the NEXT period.  This entry may not exist.  The Coinbase transaction is considered
 	// to be in the first period.  Factom's periods will initially be a minute long, and
 	// there will be 10 of them.  This may change in the future.
+
+	coinbasePatched bool
 }
 
 var _ interfaces.IFBlock = (*FBlock)(nil)
@@ -637,6 +639,20 @@ func (b *FBlock) AddCoinbase(trans interfaces.ITransaction) error {
 
 	b.Transactions = append(b.Transactions, trans)
 	return nil
+}
+
+// PatchCoinbase updates the coinbase transaction with the leader's real timestamp.
+// This timestamp is not known at the time of creation.
+func (b *FBlock) PatchCoinbase(ts interfaces.Timestamp) {
+	if len(b.Transactions) > 0 {
+		b.Transactions[0].SetTimestamp(ts)
+		b.coinbasePatched = true
+	}
+}
+
+// IsCoinbasePatched returns true when the coinbase has been patched with the real timestamp
+func (b *FBlock) IsCoinbasePatched() bool {
+	return b.coinbasePatched
 }
 
 // Add the given transaction to this block.  Reports an error if this

--- a/common/interfaces/block.go
+++ b/common/interfaces/block.go
@@ -30,6 +30,12 @@ type IFBlock interface {
 	MarshalTrans() ([]byte, error)
 	// Add a coinbase transaction.  This transaction has no inputs
 	AddCoinbase(ITransaction) error
+	// PatchCoinbase updates the coinbase transaction with the leader's real timestamp.
+	// This timestamp is not known at the time of creation.
+	PatchCoinbase(Timestamp)
+	// IsCoinbasePatched returns true when the coinbase has been patched with the real timestamp
+	IsCoinbasePatched() bool
+
 	// Add a proper transaction.  Transactions are validated before
 	// being added to the block.
 	AddTransaction(ITransaction) error

--- a/common/interfaces/state.go
+++ b/common/interfaces/state.go
@@ -198,7 +198,7 @@ type IState interface {
 	IncFactoidTrans()
 	IncDBStateAnswerCnt()
 
-	GetPendingTransactions(interface{}) []IPendingTransaction
+	GetPendingTransactions(string) []IPendingTransaction
 	// MISC
 	// ====
 

--- a/common/interfaces/transaction.go
+++ b/common/interfaces/transaction.go
@@ -89,6 +89,7 @@ type ITransaction interface {
 
 type IPendingTransaction struct {
 	TransactionID IHash           `json:"transactionid"`
+	DBHeight      uint32          `json:"dbheight"`
 	Status        string          `json:"status"`
 	Inputs        []ITransAddress `json:"inputs"`
 	Outputs       []ITransAddress `json:"outputs"`

--- a/simulation/simControl.go
+++ b/simulation/simControl.go
@@ -1077,7 +1077,7 @@ func StartSimControl(w *worker.Thread, listenTo int, listenStdin bool) {
 				case 'j' == b[0]:
 					var fpl []interfaces.IPendingTransaction
 					if len(b) > 1 {
-						fpl = fnode.Get(ListenTo).State.GetPendingTransactions(b[1])
+						fpl = fnode.Get(ListenTo).State.GetPendingTransactions(b[1:])
 					} else {
 						fpl = fnode.Get(ListenTo).State.GetPendingTransactions("")
 					}

--- a/state/state.go
+++ b/state/state.go
@@ -1120,55 +1120,41 @@ func (s *State) GetPendingEntries(params interface{}) []interfaces.IPendingEntry
 	return resp
 }
 
-func (s *State) GetPendingTransactions(params interface{}) []interfaces.IPendingTransaction {
+// GetPendingTransactions returns a list of transactions that will be included in the upcoming or future blocks
+func (s *State) GetPendingTransactions(params string) []interfaces.IPendingTransaction {
 	var flgFound bool
 
 	var currentHeightComplete = s.GetDBHeightComplete()
 	resp := make([]interfaces.IPendingTransaction, 0)
-	pls := s.ProcessLists.Lists
-	for _, pl := range pls {
-		if pl != nil {
-			// ignore old process lists
-			if pl.DBHeight > currentHeightComplete {
-				cb := pl.State.FactoidState.GetCurrentBlock()
-				ct := cb.GetTransactions()
-				for i, tran := range ct {
-					var tmp interfaces.IPendingTransaction
-					tmp.TransactionID = tran.GetSigHash()
-					if tran.GetBlockHeight() > 0 {
-						tmp.Status = constants.AckStatusDBlockConfirmedString
-					} else {
-						tmp.Status = constants.AckStatusACKString
-					}
-
-					tmp.Inputs = tran.GetInputs()
-					tmp.Outputs = tran.GetOutputs()
-					tmp.ECOutputs = tran.GetECOutputs()
-					if i > 0 {
-						ecrate := s.GetPredictiveFER()
-						ecrate, _ = tran.CalculateFee(ecrate)
-						tmp.Fees = ecrate
-					}
-
-					if params.(string) == "" {
-						flgFound = true
-					} else {
-						flgFound = tran.HasUserAddress(params.(string))
-					}
-					if flgFound == true {
-						//working through multiple process lists.  Is this transaction already in the list?
-						for _, pt := range resp {
-							if pt.TransactionID.String() == tmp.TransactionID.String() {
-								flgFound = false
-							}
-						}
-						//  flag was true to be added to the list and not already in the list
-						if flgFound == true {
-							resp = append(resp, tmp)
-						}
-					}
-				}
+	cb := s.GetFactoidState().GetCurrentBlock()
+	if cb.GetDBHeight() > currentHeightComplete {
+		for i, ta := range cb.GetTransactions() {
+			// don't return coinbase until the real timestamp is in
+			if i == 0 && !cb.IsCoinbasePatched() {
+				continue
 			}
+
+			if params != "" && !ta.HasUserAddress(params) {
+				continue
+			}
+
+			var tmp interfaces.IPendingTransaction
+			tmp.TransactionID = ta.GetSigHash()
+			tmp.DBHeight = cb.GetDBHeight()
+			if ta.GetBlockHeight() > 0 {
+				tmp.Status = constants.AckStatusDBlockConfirmedString
+			} else {
+				tmp.Status = constants.AckStatusACKString
+			}
+			tmp.Inputs = ta.GetInputs()
+			tmp.Outputs = ta.GetOutputs()
+			tmp.ECOutputs = ta.GetECOutputs()
+			if len(tmp.Inputs) > 0 {
+				ecrate := s.GetPredictiveFER()
+				ecrate, _ = ta.CalculateFee(ecrate)
+				tmp.Fees = ecrate
+			}
+			resp = append(resp, tmp)
 		}
 	}
 
@@ -1188,7 +1174,7 @@ func (s *State) GetPendingTransactions(params interface{}) []interfaces.IPending
 			var tmp interfaces.IPendingTransaction
 			tmp.TransactionID = tempTran.GetSigHash()
 			tmp.Status = constants.AckStatusNotConfirmedString
-			flgFound = tempTran.HasUserAddress(params.(string))
+			flgFound = tempTran.HasUserAddress(params)
 			tmp.Inputs = tempTran.GetInputs()
 			tmp.Outputs = tempTran.GetOutputs()
 			tmp.ECOutputs = tempTran.GetECOutputs()

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -2390,16 +2390,16 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 
 			cb := fs.GetCurrentBlock()
 			cbtx := cb.GetTransactions()[0]
-			foo := cbtx.GetTimestamp().GetTimeMilliUInt64()
+			cbTimestamp := cbtx.GetTimestamp().GetTimeMilliUInt64()
 			lts := s.LeaderTimestamp.GetTimeMilliUInt64()
-			s.LogPrintf("dbsig", "ProcessDBSig(): first  cbtx before %d dbsig %d lts %d", foo, dbsMilli, lts)
+			s.LogPrintf("dbsig", "ProcessDBSig(): first  cbtx before %d dbsig %d lts %d", cbTimestamp, dbsMilli, lts)
 
 			s.SetLeaderTimestamp(dbs.Timestamp) // SetLeaderTimestamp also updates the Message Timestamp filter
 
 			uInt64_3 := dbs.GetTimestamp().GetTimeMilliUInt64()
-			foo_3 := cbtx.GetTimestamp().GetTimeMilliUInt64()
-			lts_3 := s.LeaderTimestamp.GetTimeMilliUInt64()
-			s.LogPrintf("dbsig", "ProcessDBSig(): second cbtx before %d dbsig %d lts %d", foo_3, uInt64_3, lts_3)
+			cbTimestamp3 := cbtx.GetTimestamp().GetTimeMilliUInt64()
+			lts3 := s.LeaderTimestamp.GetTimeMilliUInt64()
+			s.LogPrintf("dbsig", "ProcessDBSig(): second cbtx before %d dbsig %d lts %d", cbTimestamp3, uInt64_3, lts3)
 			s.LogPrintf("dbsig", "ProcessDBSig(): p cbtx %p dbsig %p lts %p", cbtx.GetTimestamp().(*primitives.Timestamp), dbs.GetTimestamp().(*primitives.Timestamp), s.LeaderTimestamp.(*primitives.Timestamp))
 
 			txt, _ := cbtx.CustomMarshalText()
@@ -2407,9 +2407,9 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 
 			uInt64 := dbs.GetTimestamp().GetTimeMilliUInt64()
 
-			foo2 := cbtx.GetTimestamp().GetTimeMilliUInt64()
+			cbTimestamp2 := cbtx.GetTimestamp().GetTimeMilliUInt64()
 			cb.PatchCoinbase(dbs.Timestamp)
-			s.LogPrintf("dbsig", "ProcessDBSig(): cbtx before %d dbsig %d cbtx after %d", foo2, uInt64, cbtx.GetTimestamp().GetTimeMilliUInt64())
+			s.LogPrintf("dbsig", "ProcessDBSig(): cbtx before %d dbsig %d cbtx after %d", cbTimestamp2, uInt64, cbtx.GetTimestamp().GetTimeMilliUInt64())
 
 			txt, _ = cbtx.CustomMarshalText()
 			s.LogPrintf("dbsig", "ProcessDBSig(): coinbase after  %s", string(txt))

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -18,7 +18,6 @@ import (
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/entryBlock"
 	"github.com/FactomProject/factomd/common/entryCreditBlock"
-	"github.com/FactomProject/factomd/common/factoid"
 	"github.com/FactomProject/factomd/common/globals"
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/messages"
@@ -2389,15 +2388,16 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 			s.LogPrintf("dbsig", "1st ProcessDBSig(): %10s DBSig dbht %d leaderheight %d VMIndex %d Timestamp %x %d, leadertimestamp = %x %d",
 				s.FactomNodeName, dbs.DBHeight, s.LLeaderHeight, dbs.VMIndex, dbs.GetTimestamp().GetTimeMilli(), dbs.GetTimestamp().GetTimeMilli(), s.LeaderTimestamp.GetTimeMilliUInt64(), s.LeaderTimestamp.GetTimeMilliUInt64())
 
-			cbtx := fs.GetCurrentBlock().(*factoid.FBlock).Transactions[0].(*factoid.Transaction)
-			foo := cbtx.MilliTimestamp
+			cb := fs.GetCurrentBlock()
+			cbtx := cb.GetTransactions()[0]
+			foo := cbtx.GetTimestamp().GetTimeMilliUInt64()
 			lts := s.LeaderTimestamp.GetTimeMilliUInt64()
 			s.LogPrintf("dbsig", "ProcessDBSig(): first  cbtx before %d dbsig %d lts %d", foo, dbsMilli, lts)
 
 			s.SetLeaderTimestamp(dbs.Timestamp) // SetLeaderTimestamp also updates the Message Timestamp filter
 
 			uInt64_3 := dbs.GetTimestamp().GetTimeMilliUInt64()
-			foo_3 := cbtx.MilliTimestamp
+			foo_3 := cbtx.GetTimestamp().GetTimeMilliUInt64()
 			lts_3 := s.LeaderTimestamp.GetTimeMilliUInt64()
 			s.LogPrintf("dbsig", "ProcessDBSig(): second cbtx before %d dbsig %d lts %d", foo_3, uInt64_3, lts_3)
 			s.LogPrintf("dbsig", "ProcessDBSig(): p cbtx %p dbsig %p lts %p", cbtx.GetTimestamp().(*primitives.Timestamp), dbs.GetTimestamp().(*primitives.Timestamp), s.LeaderTimestamp.(*primitives.Timestamp))
@@ -2407,9 +2407,9 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 
 			uInt64 := dbs.GetTimestamp().GetTimeMilliUInt64()
 
-			foo2 := cbtx.MilliTimestamp
-			cbtx.MilliTimestamp = dbsMilli
-			s.LogPrintf("dbsig", "ProcessDBSig(): cbtx before %d dbsig %d cbtx after %d", foo2, uInt64, cbtx.MilliTimestamp)
+			foo2 := cbtx.GetTimestamp().GetTimeMilliUInt64()
+			cb.PatchCoinbase(dbs.Timestamp)
+			s.LogPrintf("dbsig", "ProcessDBSig(): cbtx before %d dbsig %d cbtx after %d", foo2, uInt64, cbtx.GetTimestamp().GetTimeMilliUInt64())
 
 			txt, _ = cbtx.CustomMarshalText()
 			s.LogPrintf("dbsig", "ProcessDBSig(): coinbase after  %s", string(txt))


### PR DESCRIPTION
This PR is a fix for #1006. This works by adding a flag to FBlocks that track whether or not the coinbase tx has been patched, and in return GetPendingTransactions only returns the coinbase if it has been patched. There are better ways to fix this, such as not creating the coinbase at all until the real timestamp is in, but the code frequently relies on the coinbase transaction existing. I figured this was the least-invasive method that doesn't affect existing behavior.

Changes:
* Add coinbasePatched flag to FBlock and support methods in both the block and the interface
* Add DBHeight to PendingTransaction result that indicates the expected height of the transaction (or 0 for transactions in holding)
* Change the consensus code to use the new FBlock functions instead of blind casts
* Change state.GetPendingTransactions to use string as parameter instead of interface
* Rewrite the GetPendingTransactions to remove completely unnecessary loop over VMs
* Fix console sim input that tried to send just a byte to state.GetPendingTransactions
