### PR TITLE
[Wax] Multithreaded ChainHeadFix

### DIFF
--- a/Utilities/CorrectChainHeads/correctChainHeads/correctchainheads.go
+++ b/Utilities/CorrectChainHeads/correctChainHeads/correctchainheads.go
@@ -11,6 +11,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// NOTE: This code has been deprecated but still exists as a standalone utility.
+// See modules/chainheadfix for the new version.
+
 type CorrectChainHeadConfig struct {
 	CheckFloating bool
 	Fix           bool

--- a/modules/chainheadfix/fix.go
+++ b/modules/chainheadfix/fix.go
@@ -77,6 +77,11 @@ func (f *finder) gatherHeads(workers int) error {
 		return err
 	}
 
+	// empty database
+	if head == nil {
+		return nil
+	}
+
 	f.wg.Add(workers)
 	for i := 0; i < workers; i++ {
 		go f.gatherer()

--- a/modules/chainheadfix/fix.go
+++ b/modules/chainheadfix/fix.go
@@ -1,0 +1,191 @@
+package chainheadfix
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/FactomProject/factomd/common/interfaces"
+	"github.com/FactomProject/factomd/database/databaseOverlay"
+)
+
+// Workers specifies the amounts of worker goroutines used to scan through the database.
+// There is a strong diminishing return for higher values.
+var Workers = 8
+
+// Summary of Chain Head Fixing:
+// To ensure that the database is consistent and that the database entry
+// for "GetChainHead" points to the most recent EBlock of every chain.
+//
+// This is accomplished in a multithreaded three stage process:
+//   1. Iterate over all DBlocks and save the maximum height & keymr of every chain
+//   2. Compare the accurate chain heads of 1. with the database results of chain heads
+//   3. (if enabled) Update the database for any entries that mismatch in 2.
+//
+// The order that DBlocks are iterated over doesn't matter. Currently the limiting factor
+// is the i/o from the database.
+type finder struct {
+	// general
+	db       *databaseOverlay.Overlay
+	log      *log.Entry
+	fixHeads bool
+
+	// keeping track of actual chain heads
+	// results of the first step
+	heads    map[[32]byte]*head
+	headsMtx sync.Mutex
+
+	// multithreaded administrative vars
+	wg     sync.WaitGroup
+	gather chan uint32
+	fix    chan *head
+
+	// counter of how many anomalies were detected
+	errors int64
+
+	// results of the second st ep
+	batchMtx    sync.Mutex
+	batchKeys   []interfaces.IHash
+	batchValues []interfaces.IHash
+}
+
+func (f *finder) get(id interfaces.IHash) *head {
+	f.headsMtx.Lock()
+	var ch *head
+	var ok bool
+	key := id.Fixed()
+	if ch, ok = f.heads[key]; !ok {
+		if ch, ok = f.heads[key]; !ok {
+			ch = newhead(id)
+			f.heads[key] = ch
+		}
+	}
+	f.headsMtx.Unlock()
+	return ch
+}
+
+func (f *finder) gatherHeads(workers int) error {
+	head, err := f.db.FetchDBlockHead()
+	if err != nil {
+		return err
+	}
+
+	f.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go f.gatherer()
+	}
+
+	height := head.GetDatabaseHeight()
+	log.Infof("checking chainheads of %d DBlocks", height)
+	for i := uint32(0); i <= height; i++ {
+		f.gather <- i
+	}
+	close(f.gather)
+	f.wg.Wait()
+
+	return nil
+}
+
+func (f *finder) checkHeads(workers int) {
+	f.wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go f.fixer()
+	}
+
+	for _, ch := range f.heads {
+		f.fix <- ch
+	}
+
+	close(f.fix)
+	f.wg.Wait()
+}
+
+func (f *finder) run(workers int) error {
+	if workers < 1 {
+		workers = 1
+	}
+
+	start := time.Now()
+	if err := f.gatherHeads(workers); err != nil {
+		return err
+	}
+	f.log.WithField("time", time.Since(start)).Info("chainheads gathered")
+
+	f.checkHeads(workers)
+
+	fixed := 0
+	if len(f.batchKeys) > 0 {
+		if err := f.db.SetChainHeads(f.batchKeys, f.batchValues); err != nil {
+			return err
+		}
+		fixed = len(f.batchKeys)
+	}
+
+	f.log.WithFields(log.Fields{
+		"errors":  f.errors,
+		"fixed":   fixed,
+		"checked": len(f.heads),
+		"total":   time.Since(start),
+	}).Infof("chainheadfix finished")
+
+	return nil
+}
+
+func (f *finder) gatherer() {
+	for h := range f.gather {
+		dblock, err := f.db.FetchDBlockByHeight(h)
+		if err != nil {
+			f.log.Errorf("unable to retrieve dblock for height %d: %v", h, err)
+			continue
+		}
+
+		for _, eblock := range dblock.GetEBlockDBEntries() {
+			f.get(eblock.GetChainID()).Update(int64(h), eblock.GetKeyMR())
+		}
+	}
+
+	f.wg.Done()
+}
+
+func (f *finder) fixer() {
+	for ch := range f.fix {
+		head, err := f.db.FetchHeadIndexByChainID(ch.id)
+		if err != nil {
+			f.log.Errorf("unable to retrieve a head index for chain %x: %v", ch.id, err)
+		}
+
+		if !head.IsSameAs(ch.head) {
+			atomic.AddInt64(&f.errors, 1)
+			if f.fixHeads {
+				f.batchMtx.Lock()
+				f.batchKeys = append(f.batchKeys, ch.id)
+				f.batchValues = append(f.batchValues, ch.head)
+				f.batchMtx.Unlock()
+			}
+			f.log.WithFields(log.Fields{
+				"chain":    ch.id.String(),
+				"got":      head.String(),
+				"expected": ch.head.String(),
+				"height":   ch.height,
+			}).Warn("bad chainhead found")
+		}
+	}
+	f.wg.Done()
+}
+
+// FindHeads checkes the databases to find any chains where the chain head
+// in the database does not match the actual chain head.
+// If specified, these anomalies are also fixed.
+func FindHeads(db *databaseOverlay.Overlay, fixHeads bool) error {
+	find := new(finder)
+	find.db = db
+	find.log = log.WithField("module", "chainheadfix")
+	find.heads = make(map[[32]byte]*head)
+	find.gather = make(chan uint32, 32)
+	find.fix = make(chan *head, 32)
+	find.fixHeads = fixHeads
+
+	return find.run(Workers)
+}

--- a/modules/chainheadfix/head.go
+++ b/modules/chainheadfix/head.go
@@ -1,0 +1,33 @@
+package chainheadfix
+
+import (
+	"sync"
+
+	"github.com/FactomProject/factomd/common/interfaces"
+)
+
+// head has the data necessary to figure out which eblock is the latest
+type head struct {
+	mtx    sync.Mutex
+	height int64            // max height of eblock
+	head   interfaces.IHash // keymr of max height eblock
+	id     interfaces.IHash // chain id
+}
+
+// Update will save the new information if the height is greater
+func (ch *head) Update(height int64, head interfaces.IHash) {
+	ch.mtx.Lock()
+	if height > ch.height {
+		ch.head = head
+		ch.height = height
+	}
+	ch.mtx.Unlock()
+}
+
+// create a new head for a chain
+func newhead(id interfaces.IHash) *head {
+	ch := new(head)
+	ch.id = id
+	ch.height = -1 // genesis dblock = 0
+	return ch
+}

--- a/state/factory.go
+++ b/state/factory.go
@@ -11,7 +11,6 @@ import (
 	"github.com/FactomProject/factomd/modules/chainheadfix"
 	"github.com/FactomProject/factomd/modules/livefeed"
 
-	"github.com/FactomProject/factomd/Utilities/CorrectChainHeads/correctChainHeads"
 	"github.com/FactomProject/factomd/common"
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/constants/runstate"
@@ -552,10 +551,6 @@ func (s *State) Initialize(o common.NamedObject, electionFactory interfaces.IEle
 	}
 
 	if s.CheckChainHeads.CheckChainHeads {
-		if err := chainheadfix.FindHeads(s.DB.(*databaseOverlay.Overlay), s.CheckChainHeads.Fix); err != nil {
-			panic(fmt.Errorf("chainheadfix encountered fatal error: %v\n", err))
-		}
-
 		if s.CheckChainHeads.Fix {
 			// Set dblock head to 184 if 184 is present and head is not 184
 			d, err := s.DB.FetchDBlockHead()
@@ -576,10 +571,10 @@ func (s *State) Initialize(o common.NamedObject, electionFactory interfaces.IEle
 				}
 			}
 		}
-		correctChainHeads.FindHeads(s.DB.(*databaseOverlay.Overlay), correctChainHeads.CorrectChainHeadConfig{
-			PrintFreq: 5000,
-			Fix:       s.CheckChainHeads.Fix,
-		})
+
+		if err := chainheadfix.FindHeads(s.DB.(*databaseOverlay.Overlay), s.CheckChainHeads.Fix); err != nil {
+			panic(fmt.Errorf("chainheadfix encountered fatal error: %v\n", err))
+		}
 	}
 	if s.ExportData {
 		s.DB.SetExportData(s.ExportDataSubpath)

--- a/state/factory.go
+++ b/state/factory.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/FactomProject/factomd/modules/chainheadfix"
 	"github.com/FactomProject/factomd/modules/livefeed"
 
 	"github.com/FactomProject/factomd/Utilities/CorrectChainHeads/correctChainHeads"
@@ -551,6 +552,10 @@ func (s *State) Initialize(o common.NamedObject, electionFactory interfaces.IEle
 	}
 
 	if s.CheckChainHeads.CheckChainHeads {
+		if err := chainheadfix.FindHeads(s.DB.(*databaseOverlay.Overlay), s.CheckChainHeads.Fix); err != nil {
+			panic(fmt.Errorf("chainheadfix encountered fatal error: %v\n", err))
+		}
+
 		if s.CheckChainHeads.Fix {
 			// Set dblock head to 184 if 184 is present and head is not 184
 			d, err := s.DB.FetchDBlockHead()


### PR DESCRIPTION
Motivation: I'm compiling and starting factomd a lot these days and every time I load the MainNet database, there's a ~20 second period where the chain head fix utility runs. I looked at the code and found it to be pretty incomprehensible and also single-threaded. I wanted to see if I could speed up the performance by multithreading the algorithm.

The original algorithm took between 20-21 seconds to run on average. The new code takes 11-12 seconds. The limiting factor now seems to be database i/o.

Description of new algorithm taken from comment:
https://github.com/FactomProject/factomd/blob/bbc5c85fcf05f03f72a4eb76493176c395418ff4/modules/chainheadfix/fix.go#L18-L28

Note: the old algorithm also contained a check for eblock parent block consistency checks. Is this still needed? I was hesitant to outright remove the old code but the functionality isn't enabled in factomd and has never been enabled as far as I can tell.