### PR TITLE
[Wax] Don't check for nil when nil is expected

### DIFF
--- a/common/entryBlock/entry.go
+++ b/common/entryBlock/entry.go
@@ -143,7 +143,8 @@ func (c *Entry) DatabasePrimaryIndex() (rval interfaces.IHash) {
 
 // DatabaseSecondaryIndex always returns nil (ie, no secondary index)
 func (c *Entry) DatabaseSecondaryIndex() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "Entry.DatabaseSecondaryIndex") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "Entry.DatabaseSecondaryIndex") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/increasebalance.go
+++ b/common/entryCreditBlock/increasebalance.go
@@ -92,7 +92,8 @@ func NewIncreaseBalance() *IncreaseBalance {
 
 // GetEntryHash always returns nil
 func (e *IncreaseBalance) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetEntryHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetEntryHash") }()
 
 	return nil
 }
@@ -117,7 +118,8 @@ func (e *IncreaseBalance) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *IncreaseBalance) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "IncreaseBalance.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/minutenumber.go
+++ b/common/entryCreditBlock/minutenumber.go
@@ -71,7 +71,8 @@ func (e *MinuteNumber) GetHash() (rval interfaces.IHash) {
 
 // GetSigHash always returns nil
 func (e *MinuteNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "MinuteNumber.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "MinuteNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/entryCreditBlock/serverindexnumber.go
+++ b/common/entryCreditBlock/serverindexnumber.go
@@ -79,14 +79,16 @@ func (e *ServerIndexNumber) GetHash() (rval interfaces.IHash) {
 
 // GetEntryHash always returns nil
 func (e *ServerIndexNumber) GetEntryHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetEntryHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetEntryHash") }()
 
 	return nil
 }
 
 // GetSigHash always returns nil
 func (e *ServerIndexNumber) GetSigHash() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetSigHash") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "ServerIndexNumber.GetSigHash") }()
 
 	return nil
 }

--- a/common/messages/electionMsgs/timeoutInternal.go
+++ b/common/messages/electionMsgs/timeoutInternal.go
@@ -241,7 +241,8 @@ func (m *TimeoutInternal) ElectionProcess(is interfaces.IState, elect interfaces
 }
 
 func (m *TimeoutInternal) GetServerID() (rval interfaces.IHash) {
-	defer func() { rval = primitives.CheckNil(rval, "TimeoutInternal.GetServerID") }()
+	// reenable if this function is implemented
+	// defer func() { rval = primitives.CheckNil(rval, "TimeoutInternal.GetServerID") }()
 
 	return nil
 }


### PR DESCRIPTION
This PR is identical to #967, only it's based on Wax instead of master.

Changes five functions that will always return nil from triggering the error that checks for nil results.