### PR TITLE
[Wax] Only run circle docker_build for a few branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,6 +371,21 @@ workflows:
             - test
       - docker_build:
           filters:
+            branches:
+                only:
+                    - develop
+                    - master
+                    - master-staging
+                    - community-testnet-staging
+                    - community-testnet
+                    - experimental1
+                    - experimental2
+                    - qa1
+                    - qa2
+                    - qa3
+                    - devnet1
+                    - devnet2
+                    - devnet3
             tags:
               only: /.*/
           context: org-global


### PR DESCRIPTION
Right now all PRs fail circle because of docker_build, which is restricted to a few branches. This PR limits the docker_build workflow to only those branches.