### PR TITLE
[Wax/P2P2] Allow empty seed files

### DIFF
--- a/p2p/seed.go
+++ b/p2p/seed.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"net"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -31,6 +32,10 @@ func (s *seed) retrieve() []Endpoint {
 
 	eps := make([]Endpoint, 0)
 	err := WebScanner(s.url, func(line string) {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return
+		}
 		host, port, err := net.SplitHostPort(line)
 		if err != nil {
 			s.logger.Errorf("Badly formatted line [%s]", line)

--- a/p2p/seed_test.go
+++ b/p2p/seed_test.go
@@ -16,6 +16,9 @@ func testServer() {
 	mux.HandleFunc("/seedBad.txt", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("192.168.0.1:8088\n10.12.13.14:8110"))
 	})
+	mux.HandleFunc("/seedBlank.txt", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(""))
+	})
 	mux.HandleFunc("/git.txt", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("52.17.183.121:8108\n52.17.153.126:8108\n52.19.117.149:8108\n52.18.72.212:8108\n52.19.44.249:8108\n52.214.189.110:8108\n34.249.228.82:8108\n34.248.202.6:8108\n52.19.181.120:8108\n34.248.6.133:8108"))
 	})
@@ -31,26 +34,28 @@ func Test_seed_retrieve(t *testing.T) {
 	s := newSeed("http://localhost:8000/seed.txt", 0)
 	s2 := newSeed("http://localhost:8000/seedBad.txt", 0)
 	s3 := newSeed("http://localhost:8000/git.txt", 0)
+	s4 := newSeed("http://localhost:8000/seedBlank.txt", 0)
 
 	tests := []struct {
 		name string
 		s    *seed
 		want []Endpoint
 	}{
-		{"base", s, []Endpoint{Endpoint{"127.0.0.1", "80"}, Endpoint{"192.168.0.1", "8088"}, Endpoint{"10.12.13.14", "8110"}}},
-		{"bad", s2, []Endpoint{Endpoint{"192.168.0.1", "8088"}, Endpoint{"10.12.13.14", "8110"}}},
+		{"base", s, []Endpoint{{"127.0.0.1", "80"}, {"192.168.0.1", "8088"}, {"10.12.13.14", "8110"}}},
+		{"bad", s2, []Endpoint{{"192.168.0.1", "8088"}, {"10.12.13.14", "8110"}}},
 		{"mainnet", s3, []Endpoint{
-			Endpoint{"52.17.183.121", "8108"},
-			Endpoint{"52.17.153.126", "8108"},
-			Endpoint{"52.19.117.149", "8108"},
-			Endpoint{"52.18.72.212", "8108"},
-			Endpoint{"52.19.44.249", "8108"},
-			Endpoint{"52.214.189.110", "8108"},
-			Endpoint{"34.249.228.82", "8108"},
-			Endpoint{"34.248.202.6", "8108"},
-			Endpoint{"52.19.181.120", "8108"},
-			Endpoint{"34.248.6.133", "8108"},
+			{"52.17.183.121", "8108"},
+			{"52.17.153.126", "8108"},
+			{"52.19.117.149", "8108"},
+			{"52.18.72.212", "8108"},
+			{"52.19.44.249", "8108"},
+			{"52.214.189.110", "8108"},
+			{"34.249.228.82", "8108"},
+			{"34.248.202.6", "8108"},
+			{"52.19.181.120", "8108"},
+			{"34.248.6.133", "8108"},
 		}},
+		{"blank", s4, []Endpoint{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
With the change to localseed.txt to remove debug IPs, the node reported an error `time="2020-08-20T10:27:58+02:00" level=error msg="Badly formatted line []" package=p2p subpackage=Seed url="https://raw.githubusercontent.com/FactomProject/factomproject.github.io/master/seed/localseed.txt"`. 

Changes:
* Skip blank lines during peer file parsing without errors