### PR TITLE
[Wax] Platform independent paths

### DIFF
--- a/engine/NetworkProcessorNet.go
+++ b/engine/NetworkProcessorNet.go
@@ -95,7 +95,7 @@ func FromPeerToPeer(parent *worker.Thread, fnode *fnode.FactomNode) {
 	// 		validators.
 	// TODO: Construct the proper setup and teardown of this publisher.
 	s := fnode.State
-	msgPub := pubsub.PubFactory.MsgSplit(100).Publish(s.GetFactomNodeName() + "/msgs")
+	msgPub := pubsub.PubFactory.MsgSplit(100).Publish(pubsub.GetPath(s.GetFactomNodeName(), "msgs"))
 	go msgPub.Start()
 
 	// ackHeight is used in ignoreMsg to determine if we should ignore an acknowledgment

--- a/modules/pubsub/registry.go
+++ b/modules/pubsub/registry.go
@@ -2,11 +2,13 @@ package pubsub
 
 import (
 	"fmt"
-	"path/filepath"
+	"strings"
 	"sync"
 
 	gotree "github.com/DiSiqueira/GoTree"
 )
+
+const Separator = "/"
 
 var globalReg *Registry
 var registryLogger = packageLogger.WithField("subpack", "registry")
@@ -155,5 +157,5 @@ func globalSubscribe(path string, sub IPubSubscriber) IPubSubscriber {
 }
 
 func GetPath(dirs ...string) string {
-	return filepath.Join(dirs...)
+	return strings.Join(dirs, Separator)
 }


### PR DESCRIPTION
This was driving me crazy because nobody else mentioned that the code crashed on startup. Turns out it wasn't crashing for anyone else (thanks @PaulBernier) and it's a platform specific issue due to pubsub using filepath.Join, which is meant for platform specific file paths, and one instance of a hardcoded path.

Changes:
- Use platform independent method in pubsub.GetPath
- Standardize path usage for Node/msgs channel

Note: this may have a merge conflict with https://github.com/FactomProject/factomd/pull/1005, which also changes the name. The change in #1005 supersedes this line.