### PR TITLE
[Wax] Only run circle docker_build for a few branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,21 @@ workflows:
             - test
       - docker_build:
           filters:
+            branches:
+                only:
+                    - develop
+                    - master
+                    - master-staging
+                    - community-testnet-staging
+                    - community-testnet
+                    - experimental1
+                    - experimental2
+                    - qa1
+                    - qa2
+                    - qa3
+                    - devnet1
+                    - devnet2
+                    - devnet3
             tags:
               only: /.*/
           context: org-global


### PR DESCRIPTION
Just noticed that #1024 got merged in to develop and we're missing this in the wax_rollup branch. Not sure if merging this PR will have ill effects later on but the wax branch could really use this change.