### PR TITLE
[Wax] Build registry before running state

### DIFF
--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -375,9 +375,9 @@ func makeServer(w *worker.Thread, p *globals.FactomParams) (node *fnode.FactomNo
 
 	// Election factory was created and passed int to avoid import loop
 	//node.State.BindPublishers() // REVIEW: has this been fully refactored?
-	node.State.Initialize(w, new(electionMsgs.ElectionsFactory))
 	node.State.NameInit(node, node.State.GetFactomNodeName()+"STATE", reflect.TypeOf(node.State).String())
 	node.State.BuildPubRegistry()
+	node.State.Initialize(w, new(electionMsgs.ElectionsFactory))
 
 	state0Init.Do(func() {
 		logPort = p.LogPort

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -881,9 +881,7 @@ func (s *State) MoveStateToHeight(dbheight uint32, newMinute int) {
 					DirectoryBlockHeader: dbstate.DirectoryBlock.GetHeader(),
 					Timestamp:            s.GetTimestamp(),
 				}
-				if s.Pub != nil {
-					s.Pub.Directory.Write(&directory)
-				}
+				s.Pub.Directory.Write(&directory)
 				s.LogPrintf("leader", "%v", directory)
 
 			}
@@ -949,9 +947,7 @@ func (s *State) MoveStateToHeight(dbheight uint32, newMinute int) {
 	s.DBSigLimit = s.EOMLimit               // We add or remove server only on block boundaries
 	s.LogPrintf("dbstateprocess", "MoveStateToHeight(%d-:-%d) leader=%v leaderPL=%p, leaderVMIndex=%d", dbheight, newMinute, s.Leader, s.LeaderPL, s.LeaderVMIndex)
 
-	if s.Pub != nil { // FIXME: should coordinate threads to start processing only after publish
-		s.Pub.BlkSeq.Write(&events.DBHT{DBHeight: s.LLeaderHeight, Minute: s.CurrentMinute})
-	}
+	s.Pub.BlkSeq.Write(&events.DBHT{DBHeight: s.LLeaderHeight, Minute: s.CurrentMinute})
 
 	s.Hold.ExecuteForNewHeight(s.LLeaderHeight, s.CurrentMinute) // execute held inMessages
 	s.Hold.Review()                                              // cleanup old inMessages


### PR DESCRIPTION
Some of the code in state relied on channels existing but due to race conditions not having been created yet. They were checked for being nil. This PR initializes the channels before starting the node.

Fixes #1039