### PR TITLE
remove isCompilerVersionOK check

### DIFF
--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -195,6 +195,9 @@ func isCompilerVersionOK() bool {
 	if strings.Contains(runtime.Version(), "1.14") {
 		goodenough = true
 	}
+	if strings.Contains(runtime.Version(), "1.15") {
+		goodenough = true
+	}
 	return goodenough
 }
 

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -148,11 +147,6 @@ func ParseCmdLine(args []string) *globals.FactomParams {
 		}
 
 	}
-	if !isCompilerVersionOK() {
-		fmt.Println("!!! !!! !!! ERROR: unsupported compiler version !!! !!! !!!")
-		time.Sleep(3 * time.Second)
-		os.Exit(1)
-	}
 
 	// launch debug console if requested
 	if p.DebugConsole != "" {
@@ -160,45 +154,6 @@ func ParseCmdLine(args []string) *globals.FactomParams {
 	}
 
 	return p
-}
-
-func isCompilerVersionOK() bool {
-	goodenough := false
-
-	if strings.Contains(runtime.Version(), "1.7") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.8") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.9") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.10") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.11") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.12") {
-		goodenough = true
-	}
-
-	if strings.Contains(runtime.Version(), "1.13") {
-		goodenough = true
-	}
-	if strings.Contains(runtime.Version(), "1.14") {
-		goodenough = true
-	}
-	if strings.Contains(runtime.Version(), "1.15") {
-		goodenough = true
-	}
-	return goodenough
 }
 
 var handleLogfilesOnce sync.Once

--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/FactomProject/factomd/testHelper/simulation"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/FactomProject/factomd/testHelper/simulation"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/directoryBlock"
@@ -695,7 +696,7 @@ func TestMultipleFTAccountsAPI(t *testing.T) {
 		if ok != true {
 			fmt.Println(x)
 		}
-		if resp2.Result.CurrentHeight != currentHeight || string(resp2.Result.LastSavedHeight) != string(heighestSavedHeight) {
+		if resp2.Result.CurrentHeight != currentHeight || uint32(resp2.Result.LastSavedHeight) != heighestSavedHeight {
 			t.Fatalf("Who wrote this trash code?... Expected a current height of " + fmt.Sprint(currentHeight) + " and a saved height of " + fmt.Sprint(heighestSavedHeight) + " but got " + fmt.Sprint(resp2.Result.CurrentHeight) + ", " + fmt.Sprint(resp2.Result.LastSavedHeight))
 		}
 
@@ -903,7 +904,7 @@ func TestMultipleECAccountsAPI(t *testing.T) {
 			fmt.Println(x)
 		}
 
-		if resp2.Result.CurrentHeight != currentHeight || string(resp2.Result.LastSavedHeight) != string(heighestSavedHeight) {
+		if resp2.Result.CurrentHeight != currentHeight || uint32(resp2.Result.LastSavedHeight) != heighestSavedHeight {
 			t.Fatalf("Who wrote this trash code?... Expected a current height of " + fmt.Sprint(currentHeight) + " and a saved height of " + fmt.Sprint(heighestSavedHeight) + " but got " + fmt.Sprint(resp2.Result.CurrentHeight) + ", " + fmt.Sprint(resp2.Result.LastSavedHeight))
 		}
 

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ cd $DIR															 # always from from script dir
 set -o pipefail
 
 # base go test command
-GO_TEST="go test -v -timeout=10m -vet=off"
+GO_TEST="go test -v -timeout=10m"
 
 # list modules for CI testing
 function listModules() {


### PR DESCRIPTION
I upgraded my local setup to go 1.15. As a side effect it looks like it has better static analysis and complained about some string conversion, and for good reason, so I fixed that. Finally, do not disable `vet` for tests.