### PR TITLE
improve startup logs readability

### DIFF
--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -61,8 +61,9 @@ func echo(s string, more ...interface{}) {
 
 func echoConfig(s *state.State, p *globals.FactomParams) {
 
+	fmt.Println()
 	fmt.Println(">>>>>>>>>>>>>>>>")
-	fmt.Println(">>>>>>>>>>>>>>>> Net Sim Start!")
+	fmt.Println(">>>>>>>>>>>>>>>> Factom parameters")
 	fmt.Println(">>>>>>>>>>>>>>>>")
 	fmt.Println(">>>>>>>>>>>>>>>> Listening to Node", p.ListenTo)
 	fmt.Println(">>>>>>>>>>>>>>>>")
@@ -105,7 +106,7 @@ func echoConfig(s *state.State, p *globals.FactomParams) {
 	echo("%20s %v\n", "selfaddr", s.FactomdLocations)
 	echo("%20s \"%s\"\n", "rpcuser", s.RpcUser)
 	echo("%20s \"%s\"\n", "corsdomains", s.CorsDomains)
-	echo("%20s %d\n", "Start 2nd Sync at ht", s.EntryBlockDBHeightComplete)
+	echo("%20s %d\n", "Start 2nd Sync at height", s.EntryBlockDBHeightComplete)
 
 	echo(fmt.Sprintf("%20s %d\n", "faultTimeout", elections.FaultTimeout))
 
@@ -117,6 +118,7 @@ func echoConfig(s *state.State, p *globals.FactomParams) {
 	echo("%20s \"%d\"\n", "TCP port", s.PortNumber)
 	echo("%20s \"%s\"\n", "pprof port", logPort)
 	echo("%20s \"%d\"\n", "Control Panel port", s.ControlPanelPort)
+	echo("\n\n")
 }
 
 // shutdown factomd

--- a/engine/factomd.go
+++ b/engine/factomd.go
@@ -23,8 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // packageLogger is the general logger for all engine related logs. You can add additional fields,
 // or create more context loggers off of this
 var packageLogger = log.WithFields(log.Fields{"package": "engine"})
@@ -44,11 +42,11 @@ func Run(params *FactomParams) {
 }
 
 func Factomd(w *worker.Thread, params *FactomParams, listenToStdin bool) {
-	fmt.Printf("SpawnRun compiler version: %s\n", runtime.Version())
-	fmt.Printf("Using build: %s\n", Build)
+	fmt.Printf("Compiler version: %s\n", runtime.Version())
+	fmt.Printf("Build: %s\n", Build)
 	fmt.Printf("Version: %s\n", FactomdVersion)
-	StartTime = time.Now()
-	fmt.Printf("Start time: %s\n", StartTime.String())
+	fmt.Printf("Start time: %s\n", time.Now().String())
+	fmt.Println()
 	go StartProfiler(params.MemProfileRate, params.ExposeProfiling)
 	NetStart(w, params, listenToStdin)
 }

--- a/state/factory.go
+++ b/state/factory.go
@@ -36,7 +36,6 @@ func (s *State) LoadConfigFromFile(filename string, networkFlag string) {
 	} else {
 		globals.Params.NetworkName = s.Network
 	}
-	fmt.Printf("\n\nNetwork : %s\n", s.Network)
 
 	networkName := strings.ToLower(s.Network) + "-"
 	// TODO: improve the paths after milestone 1

--- a/state/stateSaver.go
+++ b/state/stateSaver.go
@@ -79,7 +79,7 @@ func (sss *StateSaverStruct) DeleteSaveState(networkName string) error {
 
 func (sss *StateSaverStruct) LoadDBStateList(s *State, statelist *DBStateList, networkName string) error {
 	filename := NetworkIDToFilename(networkName, sss.FastBootLocation)
-	fmt.Println(statelist.State.FactomNodeName, "Loading from", filename)
+	fmt.Println(statelist.State.FactomNodeName, "Loading state from", filename)
 	b, err := LoadFromFile(s, filename)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "LoadDBStateList error:", err)
@@ -138,10 +138,8 @@ func SaveToFile(s *State, dbht uint32, b []byte, filename string) error {
 }
 
 func LoadFromFile(s *State, filename string) ([]byte, error) {
-	fmt.Fprintf(os.Stderr, "%20s Load state from %s\n", s.FactomNodeName, filename)
 	b, err := ioutil.ReadFile(filename)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%20s LoadFromFile error: %v\n", s.FactomNodeName, err)
 		return nil, err
 	}
 	return b, nil

--- a/util/config.go
+++ b/util/config.go
@@ -13,8 +13,6 @@ import (
 	gcfg "gopkg.in/gcfg.v1"
 )
 
-var _ = fmt.Print
-
 type FactomdConfig struct {
 	App struct {
 		PortNumber                             int
@@ -398,8 +396,8 @@ func ReadConfig(filename string) *FactomdConfig {
 	err = gcfg.FatalOnly(gcfg.ReadFileInto(cfg, filename))
 	if err != nil {
 		if reportedError[filename] != err.Error() {
-			fmt.Printf("Reading from '%s'\n", filename)
-			fmt.Printf("Cannot open custom config file,\nStarting with default settings.\n%v\n", err)
+			fmt.Printf("Failed reading config from '%s': %s\n", filename, err)
+			fmt.Printf("Starting with default settings.\n")
 			// Remember the error reported for this filename
 			reportedError[filename] = err.Error()
 		}


### PR DESCRIPTION
This just help on not getting overwhelm unnecessary with the start up log. We can still do much better, but that at least remove useless or redundant logs.