### PR TITLE
Fix gofmt step for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,18 +322,6 @@ jobs:
           paths:
             - /images
 
-# The flow is
-#    build
-#      |
-#      ---------- test
-#                   |
-#                   ---------- gofmt
-#                   |
-#                   ---------- docker_build
-#                   |
-#                   ---------- test_full
-#
-#
 
 workflows:
   version: 2
@@ -343,18 +331,18 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - build
       - gofmt:
           filters:
             tags:
               only: /.*/
           requires:
-            - test
+            - build
+      - test:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - gofmt
       - docker_build:
           filters:
             branches:

--- a/engine/NetworkProcessorNet.go
+++ b/engine/NetworkProcessorNet.go
@@ -94,7 +94,7 @@ func FromPeerToPeer(parent *worker.Thread, fnode *fnode.FactomNode) {
 	// TODO: Construct the proper setup and teardown of this publisher.
 	s := fnode.State
 
-  msgPub := pubsub.PubFactory.MsgSplit(100).Publish(pubsub.GetPath(s.GetFactomNodeName(), "bmv", "input"))
+	msgPub := pubsub.PubFactory.MsgSplit(100).Publish(pubsub.GetPath(s.GetFactomNodeName(), "bmv", "input"))
 	go msgPub.Start()
 
 	// ackHeight is used in ignoreMsg to determine if we should ignore an acknowledgment

--- a/test.sh
+++ b/test.sh
@@ -111,9 +111,8 @@ function testGoFmt() {
 	FILES=$(find . -name '*.go' ! -name '*_template.go')
 
 	for FILE in ${FILES[*]}; do
-		gofmt -w $FILE
-
-		if [[ $? != 0 ]]; then
+		
+		if [[ $(gofmt -l $FILE) != "" ]]; then
 			FAIL=1
 			FAILURES+=($FILE)
 		fi


### PR DESCRIPTION
This PR does 3 things:

1. Make the gofmt step actually work in CircleCI: until know that step would *always* work no matter what is pushed, because it was using option `-w` that just rewrites files locally...
2. But gofmt step in front of tests, we should fail because of linting as early as possible, no need to waste time testing if the job is going to fail anyway.
3. Fix one file that was not properly formatted (but because of 1. never got noticed)