### PR TITLE
fix(test): flaky TestProtocolV11_readWriteCheck

### DIFF
--- a/p2p/protocolV11_test.go
+++ b/p2p/protocolV11_test.go
@@ -41,7 +41,7 @@ func TestProtocolV11_readWriteCheck(t *testing.T) {
 	// write 100 random byte slices
 	data := make([][]byte, 100)
 	for i := 0; i < len(data); i++ {
-		data[i] = make([]byte, rand.Intn(4094)+4) // between 4 byte and 4KiB
+		data[i] = make([]byte, rand.Intn(4093)+4) // between 4 byte and 4KiB
 		rand.Read(data[i])
 	}
 


### PR DESCRIPTION
4093 + 4 = 4097 which is greater than the capacity of the buf slice of 4096
Error occurred: https://app.circleci.com/pipelines/github/FactomProject/factomd/406/workflows/4bae057b-dd48-4d4e-9027-8e6d1fad8895/jobs/18460