### PR TITLE
TestDBSigElection nil pointer error

### DIFF
--- a/common/messages/electionMsgs/fedVoteLevelMsg.go
+++ b/common/messages/electionMsgs/fedVoteLevelMsg.go
@@ -257,6 +257,9 @@ func (m *FedVoteLevelMsg) FollowerExecute(is interfaces.IState) {
 
 		// Add to the process list (which will get immediately processed)
 		is.LogMessage("executeMsg", "add to pl", m.Volunteer.Ack)
+
+		// make sure the message has leaderchainid set
+		m.Volunteer.Missing.SetLeaderChainID(m.Volunteer.Ack.GetLeaderChainID())
 		pl.AddToProcessList(pl.State, m.Volunteer.Ack.(*messages.Ack), m.Volunteer.Missing)
 	} else {
 		is.ElectionsQueue().Enqueue(m)

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -2543,7 +2543,7 @@ func (s *State) ProcessDBSig(dbheight uint32, msg interfaces.IMsg) bool {
 			uint32(0),
 			msg.GetVMIndex(),
 			uint32(vm.Height),
-			dbs.LeaderChainID,
+			dbs.GetLeaderChainID(),
 		)
 		s.electionsQueue.Enqueue(InMsg)
 	}


### PR DESCRIPTION
This bug happened consistently in the `TestDBSigElection` unit test, where it attempted to read from a message's LeaderChainID that was `nil`. It took me a long time to figure out where the message actually came from, and the source is the election code, pushing an audit server's volunteer message into the process list as a directory block signature message. 

This fix is two-fold:
* Change the election execute code to always set a message's LeaderChainID before adding it to the process list
* Change the reading of LeaderChainID in the ProcessDBSig method to use the function rather than the field directly (the function will never return `nil`)

Only the first item is necessary for this to be fixed, the second change is just for consistency. 

So what caused this? I'm still not entirely sure. My current working theory is that it could have been a logging change. While debugging, I noticed that if I tried to check a generic message via GetLeaderChainID(), the error would not occur since that function sets the field to be not nil. It is possible that somewhere in the previous code, GetLeaderChainID() was called for logging messages, meaning that all messages would have had the field set.

