### PR TITLE
Fix TestFilterAPIInput unit test

### DIFF
--- a/modules/debugsettings/settings.go
+++ b/modules/debugsettings/settings.go
@@ -59,7 +59,7 @@ func (s *Settings) UpdateInputRegex(re string) error {
 	return nil
 }
 
-func (s *Settings) UpdateOuputRegex(re string) error {
+func (s *Settings) UpdateOutputRegex(re string) error {
 	v, err := regexp.Compile(re)
 	if err != nil {
 		return err

--- a/simTest/MessageFilteringInput_test.go
+++ b/simTest/MessageFilteringInput_test.go
@@ -1,9 +1,10 @@
 package simtest
 
 import (
-	"github.com/FactomProject/factomd/testHelper/simulation"
 	"strings"
 	"testing"
+
+	"github.com/FactomProject/factomd/testHelper/simulation"
 
 	"github.com/FactomProject/factomd/fnode"
 

--- a/state/state.go
+++ b/state/state.go
@@ -29,6 +29,7 @@ import (
 	"github.com/FactomProject/factomd/database/databaseOverlay"
 	"github.com/FactomProject/factomd/database/leveldb"
 	"github.com/FactomProject/factomd/database/mapdb"
+	"github.com/FactomProject/factomd/modules/debugsettings"
 	"github.com/FactomProject/factomd/modules/events"
 	"github.com/FactomProject/factomd/modules/pubsub"
 	"github.com/FactomProject/factomd/modules/pubsub/pubregistry"
@@ -2376,6 +2377,9 @@ func (s *State) PassOutputRegEx(RegEx *regexp.Regexp, RegExString string) {
 	s.LogPrintf("networkOutputs", "SetOutputRegEx to '%s'", RegExString)
 	s.OutputRegEx = RegEx
 	s.OutputRegExString = RegExString
+	// this returns an error but the function that calls PassOutputRegEx already ran a
+	// .MustCompile on the string, so it will compile a second time
+	debugsettings.GetSettings(s.GetFactomNodeName()).UpdateOutputRegex(RegExString)
 }
 
 func (s *State) GetOutputRegEx() (*regexp.Regexp, string) {
@@ -2386,6 +2390,9 @@ func (s *State) PassInputRegEx(RegEx *regexp.Regexp, RegExString string) {
 	s.LogPrintf("networkInputs", "SetInputRegEx to '%s'", RegExString)
 	s.InputRegEx = RegEx
 	s.InputRegExString = RegExString
+	// this returns an error but the function that calls PassInputRegEx already ran a
+	// .MustCompile on the string, so it will compile a second time
+	debugsettings.GetSettings(s.GetFactomNodeName()).UpdateInputRegex(RegExString)
 }
 
 func (s *State) GetInputRegEx() (*regexp.Regexp, string) {


### PR DESCRIPTION
The cause of this one turns out to be fairly simple: the value being set via the API call never made it to the BMV where it filtered them, due to the state function not having the debugsettings module implemented

Changes:
* Update debugsettings when input/output filter are set in state
* Fix typo in function name

Sidenote: This unit test is not windows compatible due to its reliance on `SystemCall`. 