### PR TITLE
Fix TestDebugLocation unit test / debuglog parameter

### DIFF
--- a/engine/factomd.go
+++ b/engine/factomd.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	. "github.com/FactomProject/factomd/common/globals"
+	logger "github.com/FactomProject/factomd/log"
 	"github.com/FactomProject/factomd/modules/registry"
 	"github.com/FactomProject/factomd/modules/worker"
 	log "github.com/sirupsen/logrus"
@@ -42,6 +43,9 @@ func Run(params *FactomParams) {
 }
 
 func Factomd(w *worker.Thread, params *FactomParams, listenToStdin bool) {
+	// combination of path + regex
+	logger.SetupGlobalLogger(params.DebugLogRegEx)
+
 	fmt.Printf("Compiler version: %s\n", runtime.Version())
 	fmt.Printf("Build: %s\n", Build)
 	fmt.Printf("Version: %s\n", FactomdVersion)

--- a/log/log.go
+++ b/log/log.go
@@ -25,11 +25,10 @@ var (
 	msgmap      map[[32]byte]interfaces.IMsg
 )
 
-func init() {
+func SetupGlobalLogger(regex string) {
 	// Create a global FileLogger that assigned the filenames based on thread and logname
-
 	// Create a global logger that adds sequence numbers and timestamps
-	GlobalLogger = NewSequenceLogger(NewFileLogger("./."))
+	GlobalLogger = NewSequenceLogger(NewFileLogger(regex))
 	GlobalLogger.AddNameField("fnode", Formatter("%s"), "")
 	GlobalLogger.AddNameField("logname", Formatter("%s.txt"), "unknown-log")
 	//Add the default print fields comment then message

--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -1370,19 +1370,16 @@ func TestDebugLocation(t *testing.T) {
 	}
 	simulation.RanSimTest = true
 
-	tempdir := os.TempDir() + string(os.PathSeparator) + "logs" + string(os.PathSeparator) // get os agnostic path to the temp directory
-
-	// toss any files that might preexist this run so we don't see old files
-	err := os.RemoveAll(tempdir)
+	tempdir, err := ioutil.TempDir("", "logs")
 	if err != nil {
 		panic(err)
 	}
 
-	// make sure the directory exists
-	err = os.MkdirAll(tempdir, os.ModePerm)
-	if err != nil {
-		panic(err)
-	}
+	defer func() {
+		os.Remove(tempdir)
+	}()
+
+	tempdir += string(os.PathSeparator)
 
 	// start a sim with a select set of logs
 	state0 := simulation.SetupSim("LF", map[string]string{"--debuglog": tempdir + "holding|networkinputs|ackqueue"}, 6, 0, 0, t)
@@ -1395,13 +1392,6 @@ func TestDebugLocation(t *testing.T) {
 	DoesFileExists(tempdir+"fnode0_networkinputs.txt", t)
 	DoesFileExists(tempdir+"fnode01_networkinputs.txt", t)
 	DoesFileExists(tempdir+"fnode01_ackqueue.txt", t)
-
-	// toss the files we created since they are no longer needed
-	err = os.RemoveAll(tempdir)
-	if err != nil {
-		panic(err)
-	}
-
 }
 
 func TestDebugLocationParse(t *testing.T) {

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -57,7 +57,7 @@ func (s *State) DebugExec() (ret bool) {
 func (s *State) LogMessage(logName string, comment string, msg interfaces.IMsg) {
 	if s.DebugExec() {
 		log.GlobalLogger.Log(LogData{
-			"fnode":   "fnodeX", // don't know the fnode number
+			"fnode":   s.FactomNodeName,
 			"logname": logName,
 			"dbht":    "unknown",
 			"comment": comment,


### PR DESCRIPTION
This test wasn't working because the functionality it was supposed to test just wasn't implemented. Not sure if this code got lost somewhere in rollup or went wrong somewhere else.

Wax rewrote the --debuglog parameter to include both a path and a regular expression, but the parameter was ignored and the function call hardcoded to "./." (aka log every file in the CWD). Logging was enabled if --debuglog was set but otherwise it had no effect.

Changes: 
* Initiate the GlobalLogger in a new function (formerly `init()`) which is called in `engine.Factomd`, where the parameter can be passed to it
* Use the node's name in the logger (formerly hardcoded as "fnodex")
* Rewrite the unit test to use the golang built in functions to create temporary directories instead of doing it manually