### PR TITLE
Fix DBsigEOMElection

### DIFF
--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -427,7 +427,7 @@ func TestDBsigEOMElection(t *testing.T) {
 		s := fnode.Get(0).State
 		// wait till minute flips
 		for s.CurrentMinute != 0 {
-			runtime.Gosched()
+			time.Sleep(time.Millisecond * 100)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()
@@ -438,12 +438,12 @@ func TestDBsigEOMElection(t *testing.T) {
 	stop1 := func() {
 		s := fnode.Get(1).State
 		for s.CurrentMinute != 0 {
-			runtime.Gosched()
+			time.Sleep(time.Millisecond * 100)
 		}
 		pl := s.ProcessLists.Get(s.LLeaderHeight)
 		vm := pl.VMs[s.LeaderVMIndex]
 		for s.CurrentMinute == 0 && vm.Height == 0 {
-			runtime.Gosched()
+			time.Sleep(time.Millisecond * 100)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()
@@ -456,6 +456,7 @@ func TestDBsigEOMElection(t *testing.T) {
 	fmt.Println("Caused Elections")
 
 	simulation.WaitMinutes(state2, 1)
+	fmt.Println("Trying to bring them back")
 	// bring them back
 	simulation.RunCmd("0")
 	simulation.RunCmd("x")

--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -427,7 +427,7 @@ func TestDBsigEOMElection(t *testing.T) {
 		s := fnode.Get(0).State
 		// wait till minute flips
 		for s.CurrentMinute != 0 {
-			time.Sleep(time.Millisecond * 25)
+			time.Sleep(time.Millisecond * 100)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()
@@ -438,12 +438,12 @@ func TestDBsigEOMElection(t *testing.T) {
 	stop1 := func() {
 		s := fnode.Get(1).State
 		for s.CurrentMinute != 0 {
-			time.Sleep(time.Millisecond * 25)
+			time.Sleep(time.Millisecond * 100)
 		}
 		pl := s.ProcessLists.Get(s.LLeaderHeight)
 		vm := pl.VMs[s.LeaderVMIndex]
 		for s.CurrentMinute == 0 && vm.Height == 0 {
-			time.Sleep(time.Millisecond * 25)
+			time.Sleep(time.Millisecond * 100)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()

--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -427,7 +427,7 @@ func TestDBsigEOMElection(t *testing.T) {
 		s := fnode.Get(0).State
 		// wait till minute flips
 		for s.CurrentMinute != 0 {
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 25)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()
@@ -438,12 +438,12 @@ func TestDBsigEOMElection(t *testing.T) {
 	stop1 := func() {
 		s := fnode.Get(1).State
 		for s.CurrentMinute != 0 {
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 25)
 		}
 		pl := s.ProcessLists.Get(s.LLeaderHeight)
 		vm := pl.VMs[s.LeaderVMIndex]
 		for s.CurrentMinute == 0 && vm.Height == 0 {
-			time.Sleep(time.Millisecond * 100)
+			time.Sleep(time.Millisecond * 25)
 		}
 		s.SetNetStateOff(true)
 		wait.Done()


### PR DESCRIPTION
This unit test only failed occasionally, making debugging this very difficult, since each run takes approximately 3 minutes. I'm not entirely sure if this fixes the problem or just pushes the frequency so low that I haven't encountered another error.

In any case, I believe this was caused by some sort of race condition inside factomd due to the loops running too fast. `runtime.Gosched()` just allows the scheduler to interrupt the loop but it doesn't put the goroutine to sleep or anything like that, meaning that all the loops here were just running at full speed.

That means there could be a potential problem in a real world scenario of this occurring, though it should be noted that the test doesn't entirely reproduce the real world environment. A node in the actual network dropping behaves differently than a single simulated node on the same computer having its network toggled off.