### PR TITLE
Fix peer tests (BrainSwap, NetSync)

### DIFF
--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 
@@ -304,6 +305,14 @@ func startNetwork(w *worker.Thread, p *globals.FactomParams) {
 		constants.SetCustomCoinBaseConstants()
 	default:
 		panic("Invalid Network choice in Config File or command line. Choose MAIN, TEST, LOCAL, or CUSTOM")
+	}
+
+	if p.Peers != "" {
+		configPeers = p.Peers
+	}
+
+	if p.NetworkPortOverride > 0 {
+		networkPort = strconv.Itoa(p.NetworkPortOverride)
 	}
 
 	// FIXME: should this be relocated?


### PR DESCRIPTION
The issue was that the peers weren't connecting to each other, due to two command line parameters never making it into the P2P config: the local network port override and special peers. The code used the config file settings but did not use the command line parameters.

Both unit tests (BrainSwapA/B and NetSyncA/B) pass with this change.