### PR TITLE
Fix /Utilities build errors

### DIFF
--- a/Utilities/DatabaseGenerator/blockgen/generator.go
+++ b/Utilities/DatabaseGenerator/blockgen/generator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/FactomProject/factomd/modules/registry"
+	"github.com/FactomProject/factomd/modules/worker"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/identity"
@@ -96,7 +97,7 @@ func NewGeneratorState(conf *DBGeneratorConfig, starttime interfaces.Timestamp) 
 	s.StateSaverStruct.FastBoot = false
 	s.EFactory = new(electionMsgs.ElectionsFactory)
 	p := registry.New()
-	p.Register(s.Initialize)
+	p.Register(func(w *worker.Thread) { s.Initialize(w, new(electionMsgs.ElectionsFactory)) })
 	go p.Run()
 	p.WaitForRunning()
 	s.NetworkNumber = constants.NETWORK_CUSTOM

--- a/Utilities/DatabaseIntegrityCheck/DatabaseIntegrityCheck_test.go
+++ b/Utilities/DatabaseIntegrityCheck/DatabaseIntegrityCheck_test.go
@@ -20,14 +20,6 @@ func TestCheckDatabaseFromState(t *testing.T) {
 	CheckDatabase(state.DB.(interfaces.DBOverlay))
 }
 
-func TestCheckDatabaseFromWSAPI(t *testing.T) {
-	ctx := testHelper.CreateWebContext()
-	state := ctx.Server.Env["state"].(interfaces.IState)
-	dbase := state.GetDB().(interfaces.DBOverlay)
-
-	CheckDatabase(dbase)
-}
-
 var dbFilename string = "levelTest.db"
 
 func TestCheckDatabaseForLevelDB(t *testing.T) {

--- a/Utilities/NetworkTester/NetworkTest.go
+++ b/Utilities/NetworkTester/NetworkTest.go
@@ -17,6 +17,8 @@ import (
 	"github.com/FactomProject/factomd/common/messages"
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/engine"
+	"github.com/FactomProject/factomd/modules/registry"
+	"github.com/FactomProject/factomd/modules/worker"
 	"github.com/FactomProject/factomd/p2p"
 )
 
@@ -103,10 +105,14 @@ func InitNetwork() {
 	}
 
 	// Setup the proxy (Which translates from network parcels to Factom messages, handling addressing for directed messages)
-	p2pProxy = new(engine.P2PProxy).Init("testnode", "P2P Network").(*engine.P2PProxy)
+	p2pProxy = new(engine.P2PProxy).Initialize("testnode", "P2P Network").(*engine.P2PProxy)
 	p2pProxy.Network = network
 
-	p2pProxy.StartProxy()
+	p := registry.New()
+	p.Register(func(w *worker.Thread) {
+		p2pProxy.StartProxy(w)
+	})
+	p.Run()
 }
 
 var cntreq int32


### PR DESCRIPTION
The /Utilities folder should probably be moved out of the repo at some point. It's a collection of related but separate applications. They were somewhat kept up to date but a few of them had build errors. It's not really a problem since factomd doesn't import them and so it compiles fine but it's still annoying to see on the UI.

Fixes:
* blockgen is updated to start with the registry
* NetworkTest is updated to start with the registry
* A unit test in DatabaseIntegrityCheck was using a function that was [removed in 2019](https://github.com/FactomProject/factomd/commit/5b401da82cb0e0d3cfac0a796608e85c74058cd3). I removed the unit test
