### PR TITLE
[Nowax] Remove glide from docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,8 @@ RUN apt-get update \
     && apt-get -y install curl git \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Get glide
-RUN go get github.com/Masterminds/glide
-
 # Where factomd sources will live
 WORKDIR $GOPATH/src/github.com/FactomProject/factomd
-
-# Get the dependencies
-COPY glide.yaml glide.lock ./
-
-# Install dependencies
-RUN glide install -v
 
 # Get goveralls for testing/coverage
 RUN go get github.com/mattn/goveralls

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -3,17 +3,8 @@ FROM golang:1.14-alpine  as builder
 # Get git, make...
 RUN apk add --no-cache curl git make gcc libc-dev
 
-# Get glide
-RUN go get github.com/Masterminds/glide
-
 # Where factomd sources will live
 WORKDIR $GOPATH/src/github.com/FactomProject/factomd
-
-# Get the dependencies
-COPY glide.yaml glide.lock ./
-
-# Install dependencies
-RUN glide install -v
 
 # Populate the rest of the source
 COPY . .


### PR DESCRIPTION
Circle keeps failing the develop branch because glide is still in the docker file. Removed the glide commands in there.