### PR TITLE
[Nowax] wsapi unit test server consistency

### DIFF
--- a/testHelper/testHelper.go
+++ b/testHelper/testHelper.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"regexp"
@@ -115,6 +116,7 @@ func CreateAndPopulateTestState() *state.State {
 	s.SetLeaderTimestamp(primitives.NewTimestampFromMilliseconds(0))
 	s.DB = CreateAndPopulateTestDatabaseOverlay()
 	s.LoadConfig("", "")
+	s.SetPort(GetFreePort())
 
 	s.DirectoryBlockInSeconds = 20
 
@@ -460,4 +462,20 @@ func GetTestName() (name string) {
 	}
 
 	return name
+}
+
+func GetFreePort() int {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+
+	listener, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		panic(err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
+	return port
 }

--- a/wsapi/wsapiV1_test.go
+++ b/wsapi/wsapiV1_test.go
@@ -21,6 +21,7 @@ import (
 
 func TestHandleGetRaw(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	type RawData struct {
@@ -93,12 +94,12 @@ func TestHandleGetRaw(t *testing.T) {
 		url := fmt.Sprintf("/v1/get-raw-data/%s", v.Hash1)
 
 		rawDataResponse := new(RawDataResponse)
-		v1RequestGet(t, url, false, rawDataResponse)
+		v1RequestGet(t, url, port, false, rawDataResponse)
 
 		assert.True(t, strings.Contains(rawDataResponse.Data, v.Raw), "Looking for %v \nGetRaw %v/%v from Hash1 failed - %v", v.Hash1, i, len(toTest), rawDataResponse.Data)
 
 		url = fmt.Sprintf("/v1/get-raw-data/%s", v.Hash2)
-		v1RequestGet(t, url, false, rawDataResponse)
+		v1RequestGet(t, url, port, false, rawDataResponse)
 
 		assert.True(t, strings.Contains(rawDataResponse.Data, v.Raw), "Looking for %v \nGetRaw %v/%v from Hash2 failed - %v", v.Hash2, i, len(toTest), rawDataResponse.Data)
 	}
@@ -107,13 +108,14 @@ func TestHandleGetRaw(t *testing.T) {
 func TestHandleDirectoryBlock(t *testing.T) {
 	//initializing server
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	hash := testHelper.DBlockHeadPrimaryIndex
 	url := fmt.Sprintf("/v1/directory-block-by-keymr/%s", hash)
 
 	dBlock := new(DBlock)
-	v1RequestGet(t, url, false, dBlock)
+	v1RequestGet(t, url, port, false, dBlock)
 
 	result, err := dBlock.JSONString()
 
@@ -133,6 +135,7 @@ func TestHandleDirectoryBlock(t *testing.T) {
 
 func TestHandleEntryBlock(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	chain, err := primitives.HexToHash("df3ade9eec4b08d5379cc64270c30ea7315d8a8a1a69efe2b98a60ecdd69e604")
@@ -150,13 +153,13 @@ func TestHandleEntryBlock(t *testing.T) {
 
 		eBlock := new(EBlock)
 		url := fmt.Sprintf("/v1/entry-block-by-keymr/%s", hash)
-		v1RequestGet(t, url, false, eBlock)
+		v1RequestGet(t, url, port, false, eBlock)
 
 		assert.Equal(t, "df3ade9eec4b08d5379cc64270c30ea7315d8a8a1a69efe2b98a60ecdd69e604", eBlock.Header.ChainID, "Wrong ChainID in eBlock - %v", eBlock)
 		assert.Equal(t, int64(b.(*entryBlock.EBlock).GetHeader().GetDBHeight()), eBlock.Header.DBHeight, "DBHeight is wrong - %v vs %v", eBlock.Header.DBHeight, b.(*entryBlock.EBlock).GetHeader().GetDBHeight())
 
 		url = fmt.Sprintf("/v1/entry-block-by-keymr/%s", hash2)
-		v1RequestGet(t, url, false, eBlock)
+		v1RequestGet(t, url, port, false, eBlock)
 
 		assert.Equal(t, "df3ade9eec4b08d5379cc64270c30ea7315d8a8a1a69efe2b98a60ecdd69e604", eBlock.Header.ChainID, "Wrong ChainID in eBlock - %v", eBlock)
 		assert.Equal(t, int64(b.(*entryBlock.EBlock).GetHeader().GetDBHeight()), eBlock.Header.DBHeight, "DBHeight is wrong - %v vs %v", eBlock.Header.DBHeight, b.(*entryBlock.EBlock).GetHeader().GetDBHeight())
@@ -168,22 +171,24 @@ func TestHandleEntryBlock(t *testing.T) {
 
 func TestHandleEntryBlockInvalidHash(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	url := "/v1/entry-block-by-keymr/invalid-hash"
 
-	v1RequestGet(t, url, true, nil)
+	v1RequestGet(t, url, port, true, nil)
 }
 
 func TestHandleGetFee(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	url := "/v1/factoid-get-fee/"
 
 	type x struct{ Fee int64 }
 	fee := new(x)
-	v1RequestGet(t, url, false, fee)
+	v1RequestGet(t, url, port, false, fee)
 
 	if fee.Fee < 1 {
 		t.Errorf("%v", fee)
@@ -192,6 +197,7 @@ func TestHandleGetFee(t *testing.T) {
 
 func TestDBlockList(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	list := []string{
@@ -211,29 +217,30 @@ func TestDBlockList(t *testing.T) {
 	for _, l := range list {
 		url := fmt.Sprintf("/v1/directory-block-by-keymr/%s", l)
 		// expect a NewBlockNotFoundError
-		v1RequestGet(t, url, true, dBlock)
+		v1RequestGet(t, url, port, true, dBlock)
 	}
 
 	hash := "000000000000000000000000000000000000000000000000000000000000000d"
 
 	head := new(CHead)
 	url := fmt.Sprintf("/v1/chain-head/%s", hash)
-	v1RequestGet(t, url, false, head)
+	v1RequestGet(t, url, port, false, head)
 
 	url = fmt.Sprintf("/v1/directory-block-by-keymr/%s", head.ChainHead)
-	v1RequestGet(t, url, false, dBlock)
+	v1RequestGet(t, url, port, false, dBlock)
 }
 
 func TestBlockIteration(t *testing.T) {
 	//initializing server
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	hash := "000000000000000000000000000000000000000000000000000000000000000d"
 
 	head := new(CHead)
 	url := fmt.Sprintf("/v1/chain-head/%s", hash)
-	v1RequestGet(t, url, false, head)
+	v1RequestGet(t, url, port, false, head)
 
 	prev := head.ChainHead
 	fetched := 0
@@ -244,7 +251,7 @@ func TestBlockIteration(t *testing.T) {
 
 		block := new(DBlock)
 		url := fmt.Sprintf("/v1/directory-block-by-keymr/%s", prev)
-		v1RequestGet(t, url, false, block)
+		v1RequestGet(t, url, port, false, block)
 
 		prev = block.Header.PrevBlockKeyMR
 		fetched++
@@ -256,13 +263,14 @@ func TestBlockIteration(t *testing.T) {
 
 func TestHandleGetReceipt(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	hash := "be5fb8c3ba92c0436269fab394ff7277c67e9b2de4431b723ce5d89799c0b93a"
 
 	receipt := new(ReceiptResponse)
 	url := fmt.Sprintf("/v1/get-receipt/%s", hash)
-	v1RequestGet(t, url, false, receipt)
+	v1RequestGet(t, url, port, false, receipt)
 
 	assert.NotNil(t, receipt.Receipt, "Receipt not found!")
 
@@ -277,13 +285,14 @@ func TestHandleGetReceipt(t *testing.T) {
 
 func TestHandleGetUnanchoredReceipt(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	hash := "68a503bd3d5b87d3a41a737e430d2ce78f5e556f6a9269859eeb1e053b7f92f7"
 
 	receipt := new(ReceiptResponse)
 	url := fmt.Sprintf("/v1/get-receipt/%s", hash)
-	v1RequestGet(t, url, false, receipt)
+	v1RequestGet(t, url, port, false, receipt)
 
 	err := receipt.Receipt.Validate()
 	assert.Nil(t, err, "failed to validate receipt - %v", receipt)
@@ -296,18 +305,20 @@ func TestHandleGetUnanchoredReceipt(t *testing.T) {
 
 func TestHandleFactoidBalanceUnknownAddress(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	factoidBalanceResponse := new(FactoidBalanceResponse)
 	url := "/v1/factoid-balance/f1ba8879fcf63b596b60ccc4c69c7f6848475ac037fc63b080ba2d9502fe66a4"
 
-	v1RequestGet(t, url, false, factoidBalanceResponse)
+	v1RequestGet(t, url, port, false, factoidBalanceResponse)
 
 	assert.Equal(t, int64(0), factoidBalanceResponse.Balance, "%v", factoidBalanceResponse)
 }
 
 func TestHandleProperties(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	type V1Properties struct {
@@ -317,7 +328,7 @@ func TestHandleProperties(t *testing.T) {
 
 	properties := new(V1Properties)
 	url := "/v1/properties/"
-	v1RequestGet(t, url, false, properties)
+	v1RequestGet(t, url, port, false, properties)
 
 	assert.Equal(t, properties.Factomd_Version, state.GetFactomdVersion())
 	assert.Equal(t, "0.0.0.0", properties.Protocol_Version)
@@ -325,11 +336,12 @@ func TestHandleProperties(t *testing.T) {
 
 func TestHandleHeights(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
+	port := state.GetPort()
 	delayedStart(t, state)
 
 	heightsResponse := new(HeightsResponse)
 	url := "/v1/heights/"
-	v1RequestGet(t, url, false, heightsResponse)
+	v1RequestGet(t, url, port, false, heightsResponse)
 
 	assert.Equal(t, int64(state.GetTrueLeaderHeight()), heightsResponse.LeaderHeight)
 	assert.Equal(t, int64(state.GetHighestSavedBlk()), heightsResponse.DirectoryBlockHeight)
@@ -340,8 +352,8 @@ func TestHandleHeights(t *testing.T) {
 	assert.Equal(t, int64(state.GetEntryBlockDBHeightComplete()), heightsResponse.EntryBlockDBHeightComplete)
 }
 
-func v1RequestGet(t *testing.T, url string, expectederror bool, result interface{}) {
-	response, err := http.Get(fmt.Sprintf("http://localhost:8088/%s", url))
+func v1RequestGet(t *testing.T, url string, port int, expectederror bool, result interface{}) {
+	response, err := http.Get(fmt.Sprintf("http://localhost:%d/%s", port, url))
 	assert.Nil(t, err, "response: %v", response)
 	if response.Body != nil {
 		defer response.Body.Close()

--- a/wsapi/wsapiV1_test.go
+++ b/wsapi/wsapiV1_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestHandleGetRaw(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	type RawData struct {
 		Hash1 string
@@ -107,7 +107,7 @@ func TestHandleGetRaw(t *testing.T) {
 func TestHandleDirectoryBlock(t *testing.T) {
 	//initializing server
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	hash := testHelper.DBlockHeadPrimaryIndex
 	url := fmt.Sprintf("/v1/directory-block-by-keymr/%s", hash)
@@ -133,7 +133,7 @@ func TestHandleDirectoryBlock(t *testing.T) {
 
 func TestHandleEntryBlock(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	chain, err := primitives.HexToHash("df3ade9eec4b08d5379cc64270c30ea7315d8a8a1a69efe2b98a60ecdd69e604")
 	assert.Nil(t, err)
@@ -168,7 +168,7 @@ func TestHandleEntryBlock(t *testing.T) {
 
 func TestHandleEntryBlockInvalidHash(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	url := "/v1/entry-block-by-keymr/invalid-hash"
 
@@ -177,7 +177,7 @@ func TestHandleEntryBlockInvalidHash(t *testing.T) {
 
 func TestHandleGetFee(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	url := "/v1/factoid-get-fee/"
 
@@ -192,7 +192,7 @@ func TestHandleGetFee(t *testing.T) {
 
 func TestDBlockList(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	list := []string{
 		"508e19f65a7fc7e9cfa5a73281b5e08115ed25a1af5723350e5c21fc92c39b40", //9
@@ -227,7 +227,7 @@ func TestDBlockList(t *testing.T) {
 func TestBlockIteration(t *testing.T) {
 	//initializing server
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	hash := "000000000000000000000000000000000000000000000000000000000000000d"
 
@@ -256,7 +256,7 @@ func TestBlockIteration(t *testing.T) {
 
 func TestHandleGetReceipt(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	hash := "be5fb8c3ba92c0436269fab394ff7277c67e9b2de4431b723ce5d89799c0b93a"
 
@@ -277,7 +277,7 @@ func TestHandleGetReceipt(t *testing.T) {
 
 func TestHandleGetUnanchoredReceipt(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	hash := "68a503bd3d5b87d3a41a737e430d2ce78f5e556f6a9269859eeb1e053b7f92f7"
 
@@ -296,7 +296,7 @@ func TestHandleGetUnanchoredReceipt(t *testing.T) {
 
 func TestHandleFactoidBalanceUnknownAddress(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	factoidBalanceResponse := new(FactoidBalanceResponse)
 	url := "/v1/factoid-balance/f1ba8879fcf63b596b60ccc4c69c7f6848475ac037fc63b080ba2d9502fe66a4"
@@ -308,7 +308,7 @@ func TestHandleFactoidBalanceUnknownAddress(t *testing.T) {
 
 func TestHandleProperties(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	type V1Properties struct {
 		Protocol_Version string
@@ -325,7 +325,7 @@ func TestHandleProperties(t *testing.T) {
 
 func TestHandleHeights(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	heightsResponse := new(HeightsResponse)
 	url := "/v1/heights/"

--- a/wsapi/wsapiV2_test.go
+++ b/wsapi/wsapiV2_test.go
@@ -3,6 +3,7 @@ package wsapi_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -227,7 +228,7 @@ func TestHandleV2Requests(t *testing.T) {
 		t.Logf("test case '%s'", name)
 
 		request := primitives.NewJSON2Request(testCase.Method, 0, testCase.Message)
-		response, err := v2Request(request)
+		response, err := v2Request(request, state.GetPort())
 
 		assert.Nil(t, err, "test '%s' failed: %v \nresponse: %v", name, err, response)
 		assert.Equal(t, testCase.Error, response.Error, "test '%s' failed contains different error that expected: %v", name, response.Error)
@@ -324,13 +325,13 @@ func TestHandleV2GetRaw(t *testing.T) {
 		req := primitives.NewJSON2Request("raw-data", 1, data)
 
 		time.Sleep(time.Millisecond * 100)
-		resp, err := v2Request(req)
+		resp, err := v2Request(req, state.GetPort())
 		assert.Nil(t, err)
 		assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v but got %v \nGetRaw %v/%v from Hash1 failed - %v", v.Hash1, v.Raw, i, len(toTest), resp.String())
 
 		data.Hash = v.Hash2
 		req = primitives.NewJSON2Request("raw-data", 1, data)
-		resp, err = v2Request(req)
+		resp, err = v2Request(req, state.GetPort())
 		assert.Nil(t, err)
 		assert.True(t, strings.Contains(resp.String(), v.Raw), "Looking for %v \nGetRaw %v/%v from Hash2 failed - %v", v.Hash1, i, len(toTest), resp.String())
 	}
@@ -488,13 +489,13 @@ func Test_ecBlockToResp(t *testing.T) {
 	}
 }
 
-func v2Request(req *primitives.JSON2Request) (*primitives.JSON2Response, error) {
+func v2Request(req *primitives.JSON2Request, port int) (*primitives.JSON2Response, error) {
 	j, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := http.Post("http://localhost:8088/v2", "application/json", bytes.NewBuffer(j))
+	resp, err := http.Post(fmt.Sprintf("http://localhost:%d/v2", port), "application/json", bytes.NewBuffer(j))
 	if err != nil {
 		return nil, err
 	}

--- a/wsapi/wsapiV2_test.go
+++ b/wsapi/wsapiV2_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestHandleV2Requests(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	cases := map[string]struct {
 		Method     string
@@ -316,7 +316,7 @@ func TestHandleV2GetRaw(t *testing.T) {
 
 	//initializing server
 	state := testHelper.CreateAndPopulateTestState()
-	Start(state)
+	delayedStart(t, state)
 
 	for i, v := range toTest {
 		data := new(HashRequest)

--- a/wsapi/wsapi_test.go
+++ b/wsapi/wsapi_test.go
@@ -56,16 +56,18 @@ func TestGetEndpoints(t *testing.T) {
 	state := testHelper.CreateAndPopulateTestState()
 	delayedStart(t, state)
 
+	base := fmt.Sprintf("http://localhost:%d", state.GetPort())
+
 	cases := map[string]struct {
 		Method   string
 		Url      string
 		Expected int
 		Body     io.Reader
 	}{
-		"baseGetUrl":       {"GET", "http://localhost:8088", http.StatusNotFound, nil},
-		"basePostUrl":      {"POST", "http://localhost:8088", http.StatusNotFound, body("")},
-		"trailing-slashes": {"GET", "http://localhost:8088/v2/", http.StatusNotFound, nil},
-		"wrong-method":     {"GET", "http://localhost:8088/v1/factoid-submit/", http.StatusNotFound, nil},
+		"baseGetUrl":       {"GET", base, http.StatusNotFound, nil},
+		"basePostUrl":      {"POST", base, http.StatusNotFound, body("")},
+		"trailing-slashes": {"GET", base + "/v2/", http.StatusNotFound, nil},
+		"wrong-method":     {"GET", base + "/v1/factoid-submit/", http.StatusNotFound, nil},
 	}
 	client := &http.Client{}
 	for name, testCase := range cases {


### PR DESCRIPTION
Looked at the unit tests that were failing in wsapi and noticed that all the unit tests were using the same port for the server, which worked fine on one machine but failed on another. This PR does the following:

* Introduce a delayedStart() that waits for the web server to be active when starting for all unit tests
* Automatically detect an available port on the local system and use the random port for the web server instead of multiple unit tests using the same port

This PR might not be strictly necessary depending on the setup.