### PR TITLE
[Nowax] Reset FNodes between unit tests

### DIFF
--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -720,3 +720,8 @@ func AddNode() {
 	AddSimPeer(fnodes, i, i-1) // KLUDGE peer w/ only last node
 	startServer(i, fnodes[i], true)
 }
+
+// ResetFNodes clears the fnode slice for unit tests
+func ResetFNodes() {
+	fnodes = nil
+}

--- a/simTest/EntriesBeforeChain_test.go
+++ b/simTest/EntriesBeforeChain_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestEntriesBeforeChain(t *testing.T) {
-
+	ResetSimHome(t)
 	encode := func(s string) []byte {
 		b := bytes.Buffer{}
 		b.WriteString(s)

--- a/simTest/EntryBatch_test.go
+++ b/simTest/EntryBatch_test.go
@@ -14,7 +14,7 @@ import (
 
 // this applies chain & entry creation in 'proper' chronological order
 func TestEntryBatch(t *testing.T) {
-
+	ResetSimHome(t)
 	encode := func(s string) []byte {
 		b := bytes.Buffer{}
 		b.WriteString(s)

--- a/simTest/HoldingRebound_test.go
+++ b/simTest/HoldingRebound_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestHoldingRebound(t *testing.T) {
+	ResetSimHome(t)
 	encode := func(s string) []byte {
 		b := bytes.Buffer{}
 		b.WriteString(s)

--- a/simTest/MessageFilteringInput_test.go
+++ b/simTest/MessageFilteringInput_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFilterAPIInput(t *testing.T) {
-
+	ResetSimHome(t)
 	state0 := SetupSim("LLLAF", map[string]string{}, 25, 1, 1, t)
 
 	RunCmd("1")

--- a/simTest/MessageFilteringOutput_test.go
+++ b/simTest/MessageFilteringOutput_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFilterAPIOutput(t *testing.T) {
-
+	ResetSimHome(t)
 	state0 := SetupSim("LLLLLAAF", map[string]string{}, 25, 1, 1, t)
 
 	RunCmd("1")

--- a/simTest/PermFCTBalancesAfterMin9Election_test.go
+++ b/simTest/PermFCTBalancesAfterMin9Election_test.go
@@ -22,6 +22,7 @@ func createDepositAddresses() {
 }
 
 func TestPermFCTBalancesAfterMin9Election(t *testing.T) {
+	ResetSimHome(t)
 	createDepositAddresses()
 	state0 := SetupSim("LLAL", map[string]string{"--debuglog": "", "--faulttimeout": "10"}, 10, 1, 1, t)
 

--- a/simTest/SetupANetwork_test.go
+++ b/simTest/SetupANetwork_test.go
@@ -1,16 +1,15 @@
 package simtest
 
-import "time"
-
 import (
 	"testing"
+	"time"
 
 	. "github.com/FactomProject/factomd/engine"
 	. "github.com/FactomProject/factomd/testHelper"
 )
 
 func TestSetupANetwork(t *testing.T) {
-
+	ResetSimHome(t)
 	state0 := SetupSim("LLLLAAAFFF", map[string]string{"--debuglog": ""}, 20, 0, 0, t)
 
 	RunCmd("9")  // Puts the focus on node 9

--- a/simTest/SimWallet_test.go
+++ b/simTest/SimWallet_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSimWallet(t *testing.T) {
-
+	ResetSimHome(t)
 	a := AccountFromFctSecret("Fs31kMMKBSCDwa7tSEzjQ4EfGeXARdUS22oBEJKNSJWbLAMTsEHr")
 	b := AccountFromFctSecret("Fs2BNvoDgSoGJpWg4PvRUxqvLE28CQexp5FZM9X5qU6QvzFBUn6D")
 

--- a/simTest/factomd_test.go
+++ b/simTest/factomd_test.go
@@ -32,6 +32,7 @@ func TestOne(t *testing.T) {
 		return
 	}
 	state.MMR_enable = false // No MMR for you!
+	ResetSimHome(t)
 
 	RanSimTest = true
 

--- a/testHelper/simulation.go
+++ b/testHelper/simulation.go
@@ -618,8 +618,12 @@ func GetLongTestHome(t *testing.T) string {
 // remove files from a home dir and remake .factom config dir
 func ResetTestHome(homeDir string, t *testing.T) {
 	t.Logf("Removing old test run in %s", homeDir)
-	os.RemoveAll(homeDir)
-	os.MkdirAll(homeDir+"/.factom/m2", 0755)
+	if err := os.RemoveAll(homeDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(homeDir+"/.factom/m2", 0755); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func ResetSimHome(t *testing.T) string {

--- a/testHelper/simulation.go
+++ b/testHelper/simulation.go
@@ -133,6 +133,7 @@ func StartPeer(CmdLineOptions map[string]string) *state.State {
 // this is useful for creating scripts that will start/stop a simulation outside of the context of a unit test
 // this allows for consistent tweaking of a simulation to induce load add message loss or adjust timing
 func StartSim(nodeCount int, UserAddedOptions map[string]string) *state.State {
+	quit = make(chan struct{})
 	UserAddedOptions["--count"] = fmt.Sprintf("%v", nodeCount)
 	params := optionsToParams(UserAddedOptions)
 	return engine.Factomd(params, false).(*state.State)

--- a/testHelper/simulation.go
+++ b/testHelper/simulation.go
@@ -24,8 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var par = globals.FactomParams{}
-
 var quit = make(chan struct{})
 var ExpectedHeight, Leaders, Audits, Followers int
 var startTime, endTime time.Time
@@ -628,6 +626,7 @@ func ResetTestHome(homeDir string, t *testing.T) {
 }
 
 func ResetSimHome(t *testing.T) string {
+	engine.ResetFNodes()
 	h := GetSimTestHome(t)
 	ResetTestHome(h, t)
 	return h


### PR DESCRIPTION
The sim is set up to use `engine.fnodes` to store the simulated nodes but this is never reset between tests, meaning new tests just keep appending to the end of fnodes. This leads to errors like databases being closed (since the nodes are shut down).

Similarly, the "quit"  channel that StartSim uses was never reopened after being closed from a previous test.

Both of these changes are experimental with possible unintentional consequences.