### PR TITLE
Activation Bug Fix + Cleanup

### DIFF
--- a/activations/activationHeight.go
+++ b/activations/activationHeight.go
@@ -72,12 +72,10 @@ func init() {
 
 // String converts an Activation ID to a name
 func (id ActivationType) String() string {
-
-	n, ok := activationNameMap[id]
-	if !ok {
-		//n = fmt.Sprintf("ActivationId(%v)", id)
+	if n, ok := activationNameMap[id]; ok {
+		return n
 	}
-	return n
+	return fmt.Sprintf("ActivationId(%d)", id)
 }
 
 var netNameOnce sync.Once
@@ -102,7 +100,7 @@ func IsActive(id ActivationType, height int) bool {
 	a, ok := activationMap[id]
 
 	if !ok {
-		fmt.Fprintf(os.Stderr, "Invalid %v (%s)\n", id, id.String())
+		fmt.Fprintf(os.Stderr, "Invalid %d (%s)\n", id, id.String())
 		return false
 	}
 

--- a/activations/activationHeight.go
+++ b/activations/activationHeight.go
@@ -113,10 +113,8 @@ func IsActive(id ActivationType, height int) bool {
 
 	// use default
 	if a.defaultHeight < math.MaxInt32 {
-		fmt.Fprintf(os.Stderr, "Activation %s uses default value for network \"%s\". Activating at %d.\n", id.String(), netName, a.defaultHeight)
 		return height >= a.defaultHeight
 	}
 
-	fmt.Fprintf(os.Stderr, "Activation %s uses default value for network \"%s\". Never activating.\n", id.String(), netName)
 	return false
 }

--- a/activations/activationHeight.go
+++ b/activations/activationHeight.go
@@ -39,7 +39,7 @@ func init() {
 	var activations []activation = []activation{
 		{"TestNetCoinBasePeriod", TESTNET_COINBASE_PERIOD,
 			"Change testnet coin base payout delay to 140 blocks",
-			math.MaxInt32, // inactive unless overridden below
+			0, // always active for consistency
 			map[string]int{
 				"MAIN":                      math.MaxInt32,
 				"LOCAL":                     25,
@@ -48,7 +48,7 @@ func init() {
 		},
 		{"AuthorityMaxDelta", AUTHRORITY_SET_MAX_DELTA,
 			"Ensures fewer than half of federated notes are replaced in a single election",
-			math.MaxInt32, // inactive unless overridden below
+			0, // always active for consistency
 			map[string]int{
 				"MAIN":                      222874,
 				"LOCAL":                     25,

--- a/activations/activationHeight_test.go
+++ b/activations/activationHeight_test.go
@@ -68,17 +68,17 @@ func TestDefaults(t *testing.T) {
 
 	netName = "XXXXX:default"
 
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 25))
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 45335))
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 222874))
-	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 25))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 45335))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 222874))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
 
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25))
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 45335))
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874))
-	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 45335))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
 }

--- a/activations/activationHeight_test.go
+++ b/activations/activationHeight_test.go
@@ -1,0 +1,84 @@
+package activations
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	// override net name
+	netNameOnce.Do(func() {})
+	netName = "MAIN"
+}
+
+func TestDefaults(t *testing.T) {
+	netName = "MAIN"
+
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 25))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 45335))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 222874-1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 222874))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 222874+1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
+
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 45335))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874-1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874+1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
+
+	netName = "LOCAL"
+
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 24-1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 25))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 25+1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
+
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25-1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25+1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
+
+	netName = "CUSTOM:fct_community_test"
+
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 45335-1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 45335))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, 45335+1))
+	assert.True(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
+
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 109387-1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 109387))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 109387+1))
+	assert.True(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
+
+	netName = "XXXXX:default"
+
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 0))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 1))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 25))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 45335))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, 222874))
+	assert.False(t, IsActive(TESTNET_COINBASE_PERIOD, math.MaxInt32-1))
+
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 0))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 1))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 25))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 45335))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, 222874))
+	assert.False(t, IsActive(AUTHRORITY_SET_MAX_DELTA, math.MaxInt32-1))
+}

--- a/state/state.go
+++ b/state/state.go
@@ -3080,7 +3080,7 @@ func (s *State) IsActive(id activations.ActivationType) bool {
 
 	if !s.reportedActivations[id] {
 		if active {
-			s.LogPrintf("executeMsg", "Activating Feature %s at height %v", id.String(), highestCompletedBlk)
+			s.LogPrintf("executeMsg", "Activating Feature %s at height %d", id.String(), highestCompletedBlk)
 		} else {
 			s.LogPrintf("executeMsg", "Never activating feature %s", id.String())
 		}

--- a/state/state.go
+++ b/state/state.go
@@ -3076,14 +3076,18 @@ func (s *State) AddToReplayFilter(mask int, hash [32]byte, timestamp interfaces.
 func (s *State) IsActive(id activations.ActivationType) bool {
 	highestCompletedBlk := s.GetHighestCompletedBlk()
 
-	rval := activations.IsActive(id, int(highestCompletedBlk))
+	active := activations.IsActive(id, int(highestCompletedBlk))
 
-	if rval && !s.reportedActivations[id] {
-		s.LogPrintf("executeMsg", "Activating Feature %s at height %v", id.String(), highestCompletedBlk)
+	if !s.reportedActivations[id] {
+		if active {
+			s.LogPrintf("executeMsg", "Activating Feature %s at height %v", id.String(), highestCompletedBlk)
+		} else {
+			s.LogPrintf("executeMsg", "Never activating feature %s", id.String())
+		}
 		s.reportedActivations[id] = true
 	}
 
-	return rval
+	return active
 }
 
 func (s *State) PassOutputRegEx(RegEx *regexp.Regexp, RegExString string) {


### PR DESCRIPTION
Noticed that the /activations code was pretty messy, wanted to clean it up a bit:
* Use sync.Once instead of a bool to calculate network name
* Don't export structs not used or needed outside of package
* Add unit test that double check all the defaults

I discovered a bug where for networks that don't have a custom entry and the default is "disabled", it would always enable them on the first block. Essentially it checked for it and printed out "never activating" but returned true anyway. This fixes that, which has no effect on either MainNet or TestNet. It might have an effect on some unit tests that use a custom network, or any custom network out there.

For that reason, I changed the default to 0 (always active) to keep behavior consistent with how it used to work before. 
