### PR TITLE
Cleanup of /factomd.go + Params

### DIFF
--- a/Utilities/DatabaseCheck/EntryBlockChecks.go
+++ b/Utilities/DatabaseCheck/EntryBlockChecks.go
@@ -21,7 +21,8 @@ func main() {
 		"-startdelay=100")
 
 	params := engine.ParseCmdLine(args)
-	state := engine.Factomd(params, true)
+	params.Sim_Stdin = true
+	state := engine.Factomd(params)
 
 	CheckEntryBlocks(state.GetDB(), true)
 

--- a/common/globals/globals.go
+++ b/common/globals/globals.go
@@ -1,8 +1,12 @@
 package globals
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"reflect"
 	"sync"
+	"text/tabwriter"
 	"time"
 )
 
@@ -104,3 +108,19 @@ var Hashlog io.Writer
 var Hashes map[[32]byte]bool
 var HashesInOrder [10000]*[32]byte
 var HashNext int
+
+// PrettyPrint will print all the struct fields and their values to Stdout
+func (p *FactomParams) PrettyPrint() {
+	fmt.Println("Parameters:")
+	tw := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+
+	s := reflect.ValueOf(p).Elem()
+	t := s.Type()
+
+	for i := 0; i < s.NumField(); i++ {
+		fmt.Fprintf(tw, "%2d:\t%25s\t%s\t=\t%v\t\n",
+			i, t.Field(i).Name, s.Field(i).Type(), s.Field(i).Interface())
+	}
+
+	tw.Flush()
+}

--- a/common/globals/globals.go
+++ b/common/globals/globals.go
@@ -1,104 +1,16 @@
 package globals
 
 import (
-	"fmt"
 	"io"
-	"os"
-	"reflect"
 	"sync"
-	"text/tabwriter"
 	"time"
 )
 
 var FnodeNames map[string]string = make(map[string]string) /// use by MessageTrace debug code
-var Params FactomParams
+var Params *FactomParams
 var StartTime time.Time
 var LastDebugLogRegEx string      // used to detect if FactomParams.DebugLogRegEx was changed by the control panel
 var InputChan = make(chan string) // Get commands here
-
-type FactomParams struct {
-	AckbalanceHash           bool
-	EnableNet                bool
-	WaitEntries              bool
-	ListenTo                 int
-	Cnt                      int
-	Net                      string
-	Fnet                     string
-	DropRate                 int
-	Journal                  string
-	Journaling               bool
-	Follower                 bool
-	Leader                   bool
-	Db                       string
-	CloneDB                  string
-	PortOverride             int
-	Peers                    string
-	NetworkName              string
-	NetworkPortOverride      int
-	ControlPanelPortOverride int
-	LogPort                  string
-	BlkTime                  int
-	FaultTimeout             int
-	RoundTimeout             int
-	RuntimeLog               bool
-	Exclusive                bool
-	ExclusiveIn              bool
-	P2PIncoming              int
-	P2POutgoing              int
-	Prefix                   string
-	Rotate                   bool
-	TimeOffset               int
-	KeepMismatch             bool
-	StartDelay               int64
-	Deadline                 int
-	CustomNet                []byte
-	CustomNetName            string
-	RpcUser                  string
-	RpcPassword              string
-	FactomdTLS               bool
-	FactomdLocations         string
-	MemProfileRate           int
-	Fast                     bool
-	FastLocation             string
-	FastSaveRate             int
-	Loglvl                   string
-	Logjson                  bool
-	Svm                      bool
-	PluginPath               string
-	TorManage                bool
-	TorUpload                bool
-	Sim_Stdin                bool
-	ExposeProfiling          bool
-	UseLogstash              bool
-	LogstashURL              string
-	Sync2                    int
-	DebugConsole             string
-	StdoutLog                string
-	StderrLog                string
-	DebugLogRegEx            string
-	ConfigPath               string
-	CheckChainHeads          bool // Run checkchain heads on boot
-	FixChainHeads            bool // Only matters if CheckChainHeads == true
-	ControlPanelSetting      string
-	WriteProcessedDBStates   bool // Write processed DBStates to debug file
-	NodeName                 string
-	FactomHome               string
-	FullHashesLog            bool // Log all unique full hashes
-	DebugLogLocation         string
-	ReparseAnchorChains      bool
-
-	// LiveFeed API params
-	EnableLiveFeedAPI        bool
-	EventReceiverProtocol    string
-	EventReceiverHost        string
-	EventReceiverPort        int
-	EventSenderPort          int
-	EventFormat              string
-	EventSendStateChange     bool
-	EventBroadcastContent    string
-	EventReplayDuringStartup bool
-	PersistentReconnect      bool
-}
 
 /****************************************************************
 	DEBUG logging to keep full hash. Turned on from command line
@@ -109,18 +21,6 @@ var Hashes map[[32]byte]bool
 var HashesInOrder [10000]*[32]byte
 var HashNext int
 
-// PrettyPrint will print all the struct fields and their values to Stdout
-func (p *FactomParams) PrettyPrint() {
-	fmt.Println("Parameters:")
-	tw := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
-
-	s := reflect.ValueOf(p).Elem()
-	t := s.Type()
-
-	for i := 0; i < s.NumField(); i++ {
-		fmt.Fprintf(tw, "%2d:\t%25s\t%s\t=\t%v\t\n",
-			i, t.Field(i).Name, s.Field(i).Type(), s.Field(i).Interface())
-	}
-
-	tw.Flush()
+func init() {
+	Params = new(FactomParams)
 }

--- a/common/globals/params.go
+++ b/common/globals/params.go
@@ -1,0 +1,108 @@
+package globals
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"text/tabwriter"
+)
+
+type FactomParams struct {
+	AckbalanceHash           bool
+	EnableNet                bool
+	WaitEntries              bool
+	ListenTo                 int
+	Cnt                      int
+	Net                      string
+	Fnet                     string
+	DropRate                 int
+	Journal                  string
+	Journaling               bool
+	Follower                 bool
+	Leader                   bool
+	Db                       string
+	CloneDB                  string
+	PortOverride             int
+	Peers                    string
+	NetworkName              string
+	NetworkPortOverride      int
+	ControlPanelPortOverride int
+	LogPort                  string
+	BlkTime                  int
+	FaultTimeout             int
+	RoundTimeout             int
+	RuntimeLog               bool
+	Exclusive                bool
+	ExclusiveIn              bool
+	P2PIncoming              int
+	P2POutgoing              int
+	Prefix                   string
+	Rotate                   bool
+	TimeOffset               int
+	KeepMismatch             bool
+	StartDelay               int64
+	Deadline                 int
+	CustomNet                []byte
+	CustomNetName            string
+	RpcUser                  string
+	RpcPassword              string
+	FactomdTLS               bool
+	FactomdLocations         string
+	MemProfileRate           int
+	Fast                     bool
+	FastLocation             string
+	FastSaveRate             int
+	Loglvl                   string
+	Logjson                  bool
+	Svm                      bool
+	PluginPath               string
+	TorManage                bool
+	TorUpload                bool
+	Sim_Stdin                bool
+	ExposeProfiling          bool
+	UseLogstash              bool
+	LogstashURL              string
+	Sync2                    int
+	DebugConsole             string
+	StdoutLog                string
+	StderrLog                string
+	DebugLogRegEx            string
+	ConfigPath               string
+	CheckChainHeads          bool // Run checkchain heads on boot
+	FixChainHeads            bool // Only matters if CheckChainHeads == true
+	ControlPanelSetting      string
+	WriteProcessedDBStates   bool // Write processed DBStates to debug file
+	NodeName                 string
+	FactomHome               string
+	FullHashesLog            bool // Log all unique full hashes
+	DebugLogLocation         string
+	ReparseAnchorChains      bool
+
+	// LiveFeed API params
+	EnableLiveFeedAPI        bool
+	EventReceiverProtocol    string
+	EventReceiverHost        string
+	EventReceiverPort        int
+	EventSenderPort          int
+	EventFormat              string
+	EventSendStateChange     bool
+	EventBroadcastContent    string
+	EventReplayDuringStartup bool
+	PersistentReconnect      bool
+}
+
+// PrettyPrint will print all the struct fields and their values to Stdout
+func (p *FactomParams) PrettyPrint() {
+	fmt.Println("Parameters:")
+	tw := tabwriter.NewWriter(os.Stdout, 1, 1, 1, ' ', 0)
+
+	s := reflect.ValueOf(p).Elem()
+	t := s.Type()
+
+	for i := 0; i < s.NumField(); i++ {
+		fmt.Fprintf(tw, "%2d:\t%25s\t%s\t=\t%v\t\n",
+			i, t.Field(i).Name, s.Field(i).Type(), s.Field(i).Interface())
+	}
+
+	tw.Flush()
+}

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -60,7 +60,7 @@ func init() {
 	primitives.General = messages.General
 }
 
-func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
+func NetStart(s *state.State, p *FactomParams) {
 
 	s.PortNumber = 8088
 	s.ControlPanelPort = 8090
@@ -617,7 +617,7 @@ func NetStart(s *state.State, p *FactomParams, listenToStdin bool) {
 
 	go controlPanel.ServeControlPanel(fnodes[0].State.ControlPanelChannel, fnodes[0].State, connectionMetricsChannel, network, Build, p.NodeName)
 
-	go SimControl(p.ListenTo, listenToStdin)
+	go SimControl(p.ListenTo, p.Sim_Stdin)
 
 }
 

--- a/engine/factomParams.go
+++ b/engine/factomParams.go
@@ -13,13 +13,13 @@ import (
 	"sync"
 	"time"
 
-	. "github.com/FactomProject/factomd/common/globals"
+	"github.com/FactomProject/factomd/common/globals"
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/elections"
 )
 
 func init() {
-	p := &Params // Global copy of decoded Params global.Params
+	p := globals.Params // Local reference to make it easier to type
 
 	flag.StringVar(&p.DebugConsole, "debugconsole", "", "Enable DebugConsole on port. localhost:8093 open 8093 and spawns a telnet console, remotehost:8093 open 8093")
 	flag.StringVar(&p.StdoutLog, "stdoutlog", "", "Log stdout to a file")
@@ -106,8 +106,8 @@ func init() {
 
 }
 
-func ParseCmdLine(args []string) *FactomParams {
-	p := &Params // Global copy of decoded Params global.Params
+func ParseCmdLine(args []string) *globals.FactomParams {
+	p := globals.Params // Local reference to make it easier to type
 
 	flag.CommandLine.Parse(args)
 

--- a/engine/factomd.go
+++ b/engine/factomd.go
@@ -41,7 +41,7 @@ var _ = fmt.Print
 // or create more context loggers off of this
 var packageLogger = log.WithFields(log.Fields{"package": "engine"})
 
-func Factomd(params *FactomParams, listenToStdin bool) interfaces.IState {
+func Factomd(params *FactomParams) interfaces.IState {
 	fmt.Printf("Go compiler version: %s\n", runtime.Version())
 	fmt.Printf("Using build: %s\n", Build)
 	fmt.Printf("Version: %s\n", FactomdVersion)
@@ -62,7 +62,7 @@ func Factomd(params *FactomParams, listenToStdin bool) interfaces.IState {
 	state0.EFactory = new(electionMsgs.ElectionsFactory)
 	state0.EventService = events.NewEventService()
 
-	NetStart(state0, params, listenToStdin)
+	NetStart(state0, params)
 	return state0
 }
 

--- a/events/eventservices/eventServiceParameters_test.go
+++ b/events/eventservices/eventServiceParameters_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestEventServiceParameters_DefaultParameters(t *testing.T) {
 	config := &util.FactomdConfig{}
-	factomParams := &globals.Params
+	factomParams := globals.Params
 
 	params := selectParameters(factomParams, config)
 
@@ -75,7 +75,7 @@ func TestEventServiceParameters_ConfigParameters(t *testing.T) {
 		"never",
 		true,
 	)
-	factomParams := &globals.Params
+	factomParams := globals.Params
 
 	testParams := selectParameters(factomParams, config)
 
@@ -118,7 +118,7 @@ func TestEventServiceParameters_ParseBroadcastErrorOverride(t *testing.T) {
 		"nevers",
 		false,
 	)
-	factomParams := &globals.Params
+	factomParams := globals.Params
 	params := selectParameters(factomParams, config)
 	assert.Equal(t, eventconfig.BroadcastOnce, params.BroadcastContent)
 }

--- a/factomd.go
+++ b/factomd.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"reflect"
 	"time"
 
 	"github.com/FactomProject/factomd/common/constants/runstate"
@@ -23,19 +22,7 @@ func main() {
 	}
 
 	params := engine.ParseCmdLine(os.Args[1:])
-	fmt.Println()
-
-	fmt.Println("Parameter:")
-	s := reflect.ValueOf(params).Elem()
-	typeOfT := s.Type()
-
-	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i)
-		fmt.Printf("%d: %25s %s = %v\n", i,
-			typeOfT.Field(i).Name, f.Type(), f.Interface())
-	}
-
-	fmt.Println()
+	params.PrettyPrint()
 
 	state := engine.Factomd(params)
 	for state.GetRunState() != runstate.Stopped {

--- a/factomd.go
+++ b/factomd.go
@@ -9,26 +9,20 @@ import (
 	"os"
 
 	"reflect"
-	"runtime"
 	"time"
 
 	"github.com/FactomProject/factomd/common/constants/runstate"
-	. "github.com/FactomProject/factomd/engine"
+	"github.com/FactomProject/factomd/engine"
 )
 
 func main() {
-	// uncomment StartProfiler() to run the pprof tool (for testing)
-
-	//  Go Optimizations...
-	runtime.GOMAXPROCS(runtime.NumCPU()) // TODO: should be *2 to use hyperthreadding? -- clay
-
 	fmt.Println("Command Line Arguments:")
 
 	for _, v := range os.Args[1:] {
 		fmt.Printf("\t%s\n", v)
 	}
 
-	params := ParseCmdLine(os.Args[1:])
+	params := engine.ParseCmdLine(os.Args[1:])
 	fmt.Println()
 
 	fmt.Println("Parameter:")
@@ -42,9 +36,8 @@ func main() {
 	}
 
 	fmt.Println()
-	sim_Stdin := params.Sim_Stdin
 
-	state := Factomd(params, sim_Stdin)
+	state := engine.Factomd(params)
 	for state.GetRunState() != runstate.Stopped {
 		time.Sleep(time.Second)
 	}

--- a/testHelper/simulation.go
+++ b/testHelper/simulation.go
@@ -126,7 +126,7 @@ func optionsToParams(UserAddedOptions map[string]string) *globals.FactomParams {
 // start a single node meant to connect to an existing network
 func StartPeer(CmdLineOptions map[string]string) *state.State {
 	params := engine.ParseCmdLine(optionsToCmdLine(CmdLineOptions))
-	return engine.Factomd(params, false).(*state.State)
+	return engine.Factomd(params).(*state.State)
 }
 
 // start simulation without promoting nodes to the authority set
@@ -135,7 +135,7 @@ func StartPeer(CmdLineOptions map[string]string) *state.State {
 func StartSim(nodeCount int, UserAddedOptions map[string]string) *state.State {
 	UserAddedOptions["--count"] = fmt.Sprintf("%v", nodeCount)
 	params := optionsToParams(UserAddedOptions)
-	return engine.Factomd(params, false).(*state.State)
+	return engine.Factomd(params).(*state.State)
 }
 
 func setTestTimeouts(state0 *state.State, calcTime time.Duration) {


### PR DESCRIPTION
Wanted to clean up the entry point file a little bit:

* Remove '.' import in factomd.go
* Remove '.' import in engine
* Remove the "listen to stdin" param from engine.Factomd() and related calls since it's passed along with params already
* Move the printout of the params into the same file as the definition of params
* Use `tabwriter` for alignment
* Move parameters to their own file in globals package
* Make global parameter struct a reference