### PR TITLE
Remove useless import hints

### DIFF
--- a/common/directoryBlock/directoryBlock.go
+++ b/common/directoryBlock/directoryBlock.go
@@ -17,8 +17,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 type DirectoryBlock struct {
 	//Not Marshalized
 	DBHash     interfaces.IHash `json:"dbhash"`

--- a/common/directoryBlock/directoryBlockEntry.go
+++ b/common/directoryBlock/directoryBlockEntry.go
@@ -12,8 +12,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 type DBEntry struct {
 	ChainID interfaces.IHash `json:"chainid"`
 	KeyMR   interfaces.IHash `json:"keymr"` // Different MR in EBlockHeader

--- a/common/directoryBlock/directoryBlockHeader.go
+++ b/common/directoryBlock/directoryBlockHeader.go
@@ -13,8 +13,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 type DBlockHeader struct {
 	Version   byte   `json:"version"`
 	NetworkID uint32 `json:"networkid"`

--- a/common/entryBlock/specialEntries/ferEntry.go
+++ b/common/entryBlock/specialEntries/ferEntry.go
@@ -13,8 +13,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 // FEREntry stands for 'Factoid Exchange Rate' (FER) entry.
 type FEREntry struct {
 	Version string `json:"version"` // This appears unused

--- a/common/entryCreditBlock/ecblockBody.go
+++ b/common/entryCreditBlock/ecblockBody.go
@@ -5,8 +5,6 @@
 package entryCreditBlock
 
 import (
-	"fmt"
-
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/primitives"
 )
@@ -17,7 +15,6 @@ type ECBlockBody struct {
 	Entries []interfaces.IECBlockEntry `json:"entries"` // The EC block entries
 }
 
-var _ = fmt.Print
 var _ interfaces.Printable = (*ECBlockBody)(nil)
 var _ interfaces.IECBlockBody = (*ECBlockBody)(nil)
 

--- a/common/entryCreditBlock/ecblock_test.go
+++ b/common/entryCreditBlock/ecblock_test.go
@@ -3,7 +3,6 @@ package entryCreditBlock_test
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -14,8 +13,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/go-spew/spew"
 )
-
-var _ = fmt.Sprint("testing")
 
 // TestUnmarshalNilECBlock checks that unmarshalling nil and the empty interface result in appropriate errors
 func TestUnmarshalNilECBlock(t *testing.T) {

--- a/common/factoid/address_test.go
+++ b/common/factoid/address_test.go
@@ -6,18 +6,13 @@ package factoid_test
 
 import (
 	"bytes"
-	"math/rand"
 	"strings"
 	"testing"
 
-	"github.com/FactomProject/ed25519"
 	"github.com/FactomProject/factomd/common/constants"
 	. "github.com/FactomProject/factomd/common/factoid"
 	"github.com/FactomProject/factomd/common/primitives"
 )
-
-var _ = ed25519.Sign
-var _ = rand.New
 
 // An address
 var address1 = [constants.ADDRESS_LENGTH]byte{

--- a/common/factoid/rcd_test.go
+++ b/common/factoid/rcd_test.go
@@ -5,18 +5,12 @@
 package factoid_test
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 
-	"github.com/FactomProject/ed25519"
 	. "github.com/FactomProject/factomd/common/factoid"
 	"github.com/FactomProject/factomd/common/interfaces"
 )
-
-var _ = fmt.Printf
-var _ = ed25519.Sign
-var _ = rand.New
 
 func TestUnmarshalNilBinaryAuth(t *testing.T) {
 	defer func() {

--- a/common/factoid/signature_test.go
+++ b/common/factoid/signature_test.go
@@ -5,7 +5,6 @@
 package factoid_test
 
 import (
-	"math/rand"
 	"testing"
 
 	"github.com/FactomProject/ed25519"
@@ -14,9 +13,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/testHelper"
 )
-
-var _ = ed25519.Sign
-var _ = rand.New
 
 var sig1 [64]byte
 var sig2 [64]byte

--- a/common/factoid/transaction.go
+++ b/common/factoid/transaction.go
@@ -7,15 +7,12 @@ package factoid
 import (
 	"fmt"
 	"os"
-	"runtime/debug"
 	"time"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/primitives"
 )
-
-var _ = debug.PrintStack
 
 type Transaction struct {
 	// Not marshalled in MarshalBinary()

--- a/common/messages/directoryBlockSignature_test.go
+++ b/common/messages/directoryBlockSignature_test.go
@@ -19,8 +19,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = log.Println
-
 func TestUnmarshalNilDirectoryBlockSignature(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/common/messages/electionMsgs/electionMsgTesting/controller.go
+++ b/common/messages/electionMsgs/electionMsgTesting/controller.go
@@ -15,8 +15,6 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
-var _ = fmt.Println
-
 // Controller will be able to route messages to a set of nodes and control various
 // communication patterns
 type Controller struct {

--- a/common/messages/electionMsgs/fedVoteLevelMsg.go
+++ b/common/messages/electionMsgs/fedVoteLevelMsg.go
@@ -24,8 +24,6 @@ import (
 	"github.com/FactomProject/factomd/elections"
 )
 
-var _ = fmt.Print
-
 // FedVoteLevelMsg
 // We can vote on a majority of votes seen and issuing a vote at a particular
 // level. Only 1 vote per level can be issued per leader.

--- a/common/messages/electionMsgs/fedVoteMsg.go
+++ b/common/messages/electionMsgs/fedVoteMsg.go
@@ -22,8 +22,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // FedVoteMsg
 // We vote on the Audit Server to replace a Federated Server that fails
 // We vote to move to the next round, if the audit server fails.

--- a/common/messages/electionMsgs/fedVotePropose.go
+++ b/common/messages/electionMsgs/fedVotePropose.go
@@ -20,8 +20,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // FedVoteProposalMsg is not a majority, it is just proposing a volunteer
 type FedVoteProposalMsg struct {
 	FedVoteMsg

--- a/common/messages/electionMsgs/fedVoteVolunteerMsg.go
+++ b/common/messages/electionMsgs/fedVoteVolunteerMsg.go
@@ -21,8 +21,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // FedVoteVolunteerMsg
 // We vote on the Audit Server to replace a Federated Server that fails
 // We vote to move to the next round, if the audit server fails.

--- a/common/messages/electionMsgs/syncMsg.go
+++ b/common/messages/electionMsgs/syncMsg.go
@@ -16,8 +16,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // SyncMsg
 // If we have timed out on a message, then we sync with the other leaders on 1) the Federated Server that we
 // need to replace, and 2) the audit server that we will replace it with.

--- a/common/messages/electionMsgs/timeoutInternal.go
+++ b/common/messages/electionMsgs/timeoutInternal.go
@@ -18,8 +18,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = state.MakeMap
-
 //General acknowledge message
 type TimeoutInternal struct {
 	msgbase.MessageBase

--- a/common/messages/missingMsgResponse_test.go
+++ b/common/messages/missingMsgResponse_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
-var _ = fmt.Print
-
 func TestBadUnmarshal(t *testing.T) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/common/messages/revealEntry_test.go
+++ b/common/messages/revealEntry_test.go
@@ -6,7 +6,6 @@ package messages_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/FactomProject/factomd/common/constants"
@@ -20,8 +19,6 @@ import (
 	"github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
 )
-
-var _ = fmt.Println
 
 func TestUnmarshalNilRevealEntryMsg(t *testing.T) {
 	defer func() {

--- a/common/primitives/merkle.go
+++ b/common/primitives/merkle.go
@@ -5,14 +5,11 @@
 package primitives
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/interfaces"
 )
-
-var _ = fmt.Println
 
 // NextPowerOfTwo returns the next highest power of two from a given number if
 // it is not already a power of two.  This is a helper function used during the

--- a/controlPanel/connectionManagement_test.go
+++ b/controlPanel/connectionManagement_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/FactomProject/factomd/p2p"
 )
 
-var _ = fmt.Sprintf("")
-
 func TestFormatDuration(t *testing.T) {
 	initial := time.Now().Add(-49 * time.Hour)
 	if FormatDuration(initial) != "2 days" {

--- a/controlPanel/controlPanel_test.go
+++ b/controlPanel/controlPanel_test.go
@@ -1,7 +1,6 @@
 package controlPanel_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
 	"strings"
@@ -20,10 +19,6 @@ import (
 	//"github.com/FactomProject/factomd/common/primitives/random"
 	. "github.com/FactomProject/factomd/testHelper"
 )
-
-var _ = time.Now()
-
-var _ = fmt.Sprintf("")
 
 // Enable for long test
 var LongTest bool = false

--- a/controlPanel/searchResultHandler.go
+++ b/controlPanel/searchResultHandler.go
@@ -24,8 +24,6 @@ import (
 	"github.com/FactomProject/factomd/common/factoid"
 )
 
-var _ = htemp.HTMLEscaper("sdf")
-
 func HandleSearchResult(content *SearchedStruct, w http.ResponseWriter) {
 	// Functions able to be used within the html
 	funcMap := template.FuncMap{

--- a/controlPanel/utils_test.go
+++ b/controlPanel/utils_test.go
@@ -1,13 +1,10 @@
 package controlPanel_test
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/FactomProject/factomd/controlPanel"
 )
-
-var _ = fmt.Sprintf("")
 
 func TestHeightToJsonStruct(t *testing.T) {
 	j := HeightToJsonStruct(uint32(32))

--- a/database/securedb/metadata.go
+++ b/database/securedb/metadata.go
@@ -10,8 +10,6 @@ import (
 	llog "github.com/FactomProject/factomd/log"
 )
 
-var _ = fmt.Sprint
-
 type SecureDBMetaData struct {
 	Salt      primitives.ByteSlice
 	Challenge primitives.ByteSlice

--- a/elections/elections.go
+++ b/elections/elections.go
@@ -12,9 +12,6 @@ import (
 	"github.com/FactomProject/factomd/util/atomic"
 )
 
-var _ = fmt.Print
-var _ = time.Tick
-
 var FaultTimeout int = 60 // This value only lasts till the command line is parse which will set it.
 var RoundTimeout int = 20 // This value only lasts till the command line is parse which will set it.
 

--- a/elections/support.go
+++ b/elections/support.go
@@ -2,13 +2,10 @@ package elections
 
 import (
 	"bytes"
-	"fmt"
 
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/primitives"
 )
-
-var _ = fmt.Print
 
 func (e *Elections) Sort(serv []interfaces.IServer) bool {
 	changed := false

--- a/electionsCore/controller/controller.go
+++ b/electionsCore/controller/controller.go
@@ -12,8 +12,6 @@ import (
 	"github.com/FactomProject/factomd/electionsCore/testhelper"
 )
 
-var _ = fmt.Println
-
 type ControllerInterpreter struct {
 	*Controller
 

--- a/electionsCore/controller/router.go
+++ b/electionsCore/controller/router.go
@@ -7,8 +7,6 @@ import (
 	"github.com/FactomProject/factomd/electionsCore/imessage"
 )
 
-var _ = fmt.Println
-
 // Router helps keep route patterns for returning messages
 // Each election has a queue, and each step consumes 1 message from the queue
 // and adds to some number of queues

--- a/electionsCore/controller/scenario_test.go
+++ b/electionsCore/controller/scenario_test.go
@@ -1,14 +1,11 @@
 package controller_test
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/FactomProject/factomd/electionsCore/controller"
 	. "github.com/FactomProject/factomd/electionsCore/errorhandling"
 )
-
-var _ = fmt.Println
 
 /*
 Scenario found

--- a/electionsCore/election/election.go
+++ b/electionsCore/election/election.go
@@ -11,8 +11,6 @@ import (
 	. "github.com/FactomProject/factomd/electionsCore/primitives"
 )
 
-var _ = fmt.Println
-
 type Election struct {
 	// Level 0 volunteer votes map[vol]map[leader]msg
 	VolunteerVotes map[Identity]map[Identity]*messages.VoteMessage

--- a/electionsCore/election/volunteercontrol/volunteercontrol.go
+++ b/electionsCore/election/volunteercontrol/volunteercontrol.go
@@ -3,13 +3,9 @@ package volunteercontrol
 import (
 	"math"
 
-	"fmt"
-
 	"github.com/FactomProject/factomd/electionsCore/messages"
 	. "github.com/FactomProject/factomd/electionsCore/primitives"
 )
-
-var _ = fmt.Println
 
 // VolunteerControl will keep a record of all votes
 // for a given volunteer and produce the best vote

--- a/electionsCore/election/volunteercontrol/volunteercontrol_test.go
+++ b/electionsCore/election/volunteercontrol/volunteercontrol_test.go
@@ -1,14 +1,8 @@
 package volunteercontrol_test
 
 import (
-	"fmt"
 	"testing"
-
-	. "github.com/FactomProject/factomd/electionsCore/election/volunteercontrol"
 )
-
-var _ = NewVolunteerControl
-var _ = fmt.Println
 
 //func TestSimpleVolunteerControl(t *testing.T) {
 //	as := testhelper.NewAuthSetHelper(3, 3)

--- a/electionsCore/testhelper/authsethelper_test.go
+++ b/electionsCore/testhelper/authsethelper_test.go
@@ -1,15 +1,12 @@
 package testhelper_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/FactomProject/factomd/electionsCore/messages"
 	"github.com/FactomProject/factomd/electionsCore/primitives"
 	. "github.com/FactomProject/factomd/electionsCore/testhelper"
 )
-
-var _ = fmt.Println
 
 func TestMajority(t *testing.T) {
 	ah := NewAuthSetHelper(5, 5)

--- a/engine/MsgLogging.go
+++ b/engine/MsgLogging.go
@@ -11,8 +11,6 @@ import (
 	"github.com/FactomProject/factomd/common/interfaces"
 )
 
-var _ = fmt.Print
-
 type msglist struct {
 	fnode *FactomNode
 	out   bool // True if this is an output.

--- a/engine/NetStart.go
+++ b/engine/NetStart.go
@@ -33,8 +33,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 type FactomNode struct {
 	Index    int
 	State    *state.State

--- a/engine/NetworkProcessorNet.go
+++ b/engine/NetworkProcessorNet.go
@@ -17,8 +17,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 func NetworkProcessorNet(fnode *FactomNode) {
 	go Peers(fnode)
 	go NetworkOutputs(fnode)

--- a/engine/SimPeer.go
+++ b/engine/SimPeer.go
@@ -5,7 +5,6 @@
 package engine
 
 import (
-	"bytes"
 	"fmt"
 	"time"
 
@@ -14,9 +13,6 @@ import (
 	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/messages/msgsupport"
 )
-
-var _ = fmt.Print
-var _ = bytes.Compare
 
 type SimPacket struct {
 	data []byte

--- a/engine/factomd.go
+++ b/engine/factomd.go
@@ -31,8 +31,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-
 // winServiceMain is only invoked on Windows.  It detects when btcd is running
 // as a service and reacts accordingly.
 //var winServiceMain func() (bool, error)

--- a/engine/pluginMap.go
+++ b/engine/pluginMap.go
@@ -19,9 +19,6 @@ import (
 // How often to check the plugin if it has messages ready
 var CHECK_BUFFER time.Duration = 2 * time.Second
 
-var _ log.Logger
-var _ = ioutil.Discard
-
 // pluginMap is the map of plugins we can dispense.
 var pluginMap = map[string]plugin.Plugin{
 	"manager": &IManagerPlugin{},

--- a/engine/simControl.go
+++ b/engine/simControl.go
@@ -30,7 +30,6 @@ import (
 	"github.com/FactomProject/factomd/wsapi"
 )
 
-var _ = fmt.Print
 var SortByID bool
 var VerboseFaultOutput = false
 var VerboseAuthoritySet = false
@@ -90,7 +89,6 @@ func GetFocus() *FactomNode {
 }
 
 func SimControl(listenTo int, listenStdin bool) {
-	var _ = time.Sleep
 	var summary int
 	var elections int
 	var simelections int

--- a/state/ack_test.go
+++ b/state/ack_test.go
@@ -11,15 +11,11 @@ import (
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/entryCreditBlock"
-	"github.com/FactomProject/factomd/common/interfaces"
 	"github.com/FactomProject/factomd/common/messages"
 	"github.com/FactomProject/factomd/common/primitives"
 	. "github.com/FactomProject/factomd/state"
 	. "github.com/FactomProject/factomd/testHelper"
 )
-
-var _ interfaces.IMsg
-var _ = NewProcessList
 
 func TestIsStateFullySynced(t *testing.T) {
 	s1_good := CreateAndPopulateTestStateAndStartValidator()

--- a/state/crossBootReplay.go
+++ b/state/crossBootReplay.go
@@ -13,8 +13,6 @@ import (
 	"github.com/FactomProject/factomd/database/mapdb"
 )
 
-var _ = fmt.Println
-
 // DB Buckets
 var (
 	heightBucket = []byte("Heights")

--- a/state/crossBootReplay_test.go
+++ b/state/crossBootReplay_test.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/FactomProject/factomd/state"
 )
 
-var _ = fmt.Printf
-
 func TestMarshalableUint32_MarshalBinary(t *testing.T) {
 	for i := 0; i < 5000; i++ {
 		u := random.RandUInt32()

--- a/state/dbStateManager.go
+++ b/state/dbStateManager.go
@@ -5,12 +5,10 @@
 package state
 
 import (
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/FactomProject/factomd/common/adminBlock"
 	"github.com/FactomProject/factomd/common/constants"
@@ -27,10 +25,6 @@ import (
 
 	llog "github.com/FactomProject/factomd/log"
 )
-
-var _ = hex.EncodeToString
-var _ = fmt.Print
-var _ = time.Now()
 
 type DBState struct {
 	IsNew bool

--- a/state/dbStateManager_test.go
+++ b/state/dbStateManager_test.go
@@ -16,10 +16,6 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
-var _ = fmt.Printf
-var _ = factoid.GetGenesisFBlock
-var _ = constants.SIGNATURE_LENGTH
-
 // Will verify a directory blc
 func verifyBlocks(s *State, dbstates []interfaces.IMsg) []string {
 	errs := make([]string, 0)

--- a/state/factoidstate_test.go
+++ b/state/factoidstate_test.go
@@ -5,7 +5,6 @@
 package state_test
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -21,7 +20,6 @@ import (
 )
 
 var fs interfaces.IFactoidState
-var _ = fmt.Print
 
 func RandBal() int64 {
 	switch rand.Int() & 7 {

--- a/state/fullBlock_test.go
+++ b/state/fullBlock_test.go
@@ -2,15 +2,12 @@ package state_test
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 
 	"github.com/FactomProject/factomd/common/primitives/random"
 	. "github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
 )
-
-var _ = fmt.Sprint
 
 func TestUInt32Bytes(t *testing.T) {
 	var i uint32 = 0

--- a/state/loadDatabase.go
+++ b/state/loadDatabase.go
@@ -21,8 +21,6 @@ import (
 	"github.com/FactomProject/factomd/common/primitives"
 )
 
-var _ = fmt.Print
-
 func humanizeDuration(duration time.Duration) string {
 	hours := int64(duration.Hours())
 	minutes := int64(math.Mod(duration.Minutes(), 60))

--- a/state/processList.go
+++ b/state/processList.go
@@ -28,9 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = fmt.Print
-var _ = log.Print
-
 var plLogger = packageLogger.WithFields(log.Fields{"subpack": "process-list"})
 
 type ProcessList struct {

--- a/state/processListManager.go
+++ b/state/processListManager.go
@@ -6,13 +6,9 @@ package state
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/FactomProject/factomd/common/interfaces"
 )
-
-var _ = fmt.Print
-var _ = log.Print
 
 type ProcessLists struct {
 	State        *State         // Pointer to the state object

--- a/state/processList_test.go
+++ b/state/processList_test.go
@@ -5,7 +5,6 @@
 package state_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/FactomProject/factomd/common/interfaces"
@@ -14,8 +13,6 @@ import (
 	. "github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
 )
-
-var _ = fmt.Print
 
 func TestProcessListString(t *testing.T) {
 	// The string function is called in some unit tests, and lines that show offline nodes is sometimes hit. This

--- a/state/queues_test.go
+++ b/state/queues_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -9,8 +8,6 @@ import (
 	"github.com/FactomProject/factomd/common/messages"
 	. "github.com/FactomProject/factomd/state"
 )
-
-var _ = fmt.Println
 
 func TestTimeSinceNegative(t *testing.T) {
 	RegisterPrometheus()

--- a/state/replay.go
+++ b/state/replay.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/FactomProject/factomd/common/constants"
 	"github.com/FactomProject/factomd/common/interfaces"
@@ -19,9 +18,6 @@ import (
 
 const Range = 60                // Double this for the period we protect, i.e. 120 means +/- 120 minutes
 const numBuckets = Range*2 + 60 // Cover the range in the future and in the past, with an hour buffer.
-
-var _ = time.Now()
-var _ = fmt.Print
 
 type Replay struct {
 	Mutex    sync.Mutex

--- a/state/replay_test.go
+++ b/state/replay_test.go
@@ -7,7 +7,6 @@ package state_test
 import (
 	"fmt"
 	"math/rand"
-	"net/http/pprof"
 	"testing"
 	"time"
 
@@ -17,16 +16,12 @@ import (
 	. "github.com/FactomProject/factomd/state"
 )
 
-var _ = fmt.Printf
-var _ = rand.New
-
 var hour = int64(60 * 60)
 
 var r = Replay{}
 
 var spanMin int64 = 60 // How many hours +/- that will be valid (1== valid 1 hour in the past to 1 hour in the future)
 var speed int64 = 1000 // Speed in milliseconds (max) that we will move the clock
-var _ = pprof.Cmdline
 
 func Test_Replay(test *testing.T) {
 	type mh struct {

--- a/state/safeMsgMap.go
+++ b/state/safeMsgMap.go
@@ -9,8 +9,6 @@ import (
 	"github.com/FactomProject/factomd/util/atomic"
 )
 
-var _ = fmt.Println
-
 // SafeMsgMap is a threadsafe map[[32]byte]interfaces.IMsg
 type SafeMsgMap struct {
 	msgmap map[[32]byte]interfaces.IMsg

--- a/state/state.go
+++ b/state/state.go
@@ -48,8 +48,6 @@ import (
 // or create more context loggers off of this
 var packageLogger = log.WithFields(log.Fields{"package": "state"})
 
-var _ = fmt.Print
-
 type State struct {
 	Logger            *log.Entry
 	RunState          runstate.RunState

--- a/state/stateConsensus.go
+++ b/state/stateConsensus.go
@@ -33,7 +33,6 @@ import (
 // or create more context loggers off of this
 var consenLogger = packageLogger.WithFields(log.Fields{"subpack": "consensus"})
 
-var _ = fmt.Print
 var _ = (*hash.Hash32)(nil)
 
 //***************************************************************

--- a/state/stateConsensus_test.go
+++ b/state/stateConsensus_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/FactomProject/factomd/testHelper"
 )
 
-var _ = NewProcessList
-
 func TestIsHighestCommit(t *testing.T) {
 	s := testHelper.CreateAndPopulateTestStateAndStartValidator()
 

--- a/state/stateDisplay_test.go
+++ b/state/stateDisplay_test.go
@@ -11,10 +11,7 @@ import (
 	//"github.com/FactomProject/factomd/common/primitives"
 	"github.com/FactomProject/factomd/common/messages/electionMsgs"
 	"github.com/FactomProject/factomd/state"
-	"github.com/FactomProject/factomd/util"
 )
-
-var _ = util.ReadConfig
 
 func TestDisplay(t *testing.T) {
 	s := new(state.State)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -16,12 +16,8 @@ import (
 	"github.com/FactomProject/factomd/state"
 	. "github.com/FactomProject/factomd/state"
 	"github.com/FactomProject/factomd/testHelper"
-	"github.com/FactomProject/factomd/util"
 	log "github.com/sirupsen/logrus"
 )
-
-var _ = log.Print
-var _ = util.ReadConfig
 
 func TestInit(t *testing.T) {
 	s := testHelper.CreateEmptyTestState()

--- a/testHelper/stateFERHelper.go
+++ b/testHelper/stateFERHelper.go
@@ -21,8 +21,6 @@ import (
 	"github.com/FactomProject/factomd/state"
 )
 
-var _ = fmt.Print
-
 type FEREntryWithHeight struct {
 	AnFEREntry interfaces.IEBEntry
 	Height     uint32

--- a/util/config.go
+++ b/util/config.go
@@ -13,8 +13,6 @@ import (
 	gcfg "gopkg.in/gcfg.v1"
 )
 
-var _ = fmt.Print
-
 type FactomdConfig struct {
 	App struct {
 		PortNumber                             int


### PR DESCRIPTION
Not sure why there are so many of these in the codebase but I assume they're leftovers from back when golang tooling wasn't very good? There are a lot of import hints for things like fmt which really shouldn't be necessary.